### PR TITLE
Run Writerside checks on PRs and locally

### DIFF
--- a/.claude/agents/documenter.md
+++ b/.claude/agents/documenter.md
@@ -100,6 +100,34 @@ make it read better. A snippet that does not match the source is worse than no s
 Fence C# snippets with the exact language tag `C#`, never `csharp`. Writerside does not recognize
 the `csharp` tag correctly.
 
+### Headings become anchor ids: keep them unique per page
+
+Writerside derives an anchor id from every heading's text (`## Generated C#` becomes
+`generated-c`), and ids must be unique within a page or the Docs CI build fails with MRK003.
+The page shape below repeats `Generated C#` and `Using it from C#` across sections, so the
+moment a page has more than one of either, every later occurrence needs an explicit unique id
+scoped to its section:
+
+```
+### Generated C# {id="property-generated-c"}
+```
+
+### Run the docs check before you report
+
+The Docs CI (`.github/workflows/docs.yml`) builds the Writerside instance and fails on
+build-time errors from the JetBrains checker (duplicate element ids, broken links and anchors,
+missing topics in `knn.tree`, and so on). Catch it yourself before you report:
+
+```bash
+scripts/verify-docs.sh
+```
+
+This runs the **same builder image and checks as CI**, locally, via Docker. It needs the Docker
+daemon: if it says the daemon is unreachable, run `colima start` and retry. It does not touch
+Gradle or `build/`, so it is always safe to run even when the refactorer holds the project lock.
+If it fails, fix the pages and rerun until it passes; a report with this check failing is not
+done.
+
 Use Writerside admonitions sparingly when information needs to stand out: `<note>` for important
 constraints or guidance, `<tip>` for optional advice, and `<warning>` for harmful consequences.
 Keep ordinary explanatory text as paragraphs. Inside an admonition, use semantic `<p>`, `<code>`,
@@ -191,6 +219,7 @@ instead.
 - Every generated symbol you cited exists in the real generated output.
 - No em-dashes in your prose.
 - `grep -rn "topic=" docs/knn.tree` lists every page you added.
+- `scripts/verify-docs.sh` passes.
 
 Report: (1) pages amended and what changed, (2) any Limitations claim you deleted, (3) anything the
 implementation does that contradicts the ADR or FEATURES.md, (4) any snippet you could not back with

--- a/.claude/agents/documenter.md
+++ b/.claude/agents/documenter.md
@@ -123,7 +123,8 @@ scripts/verify-docs.sh
 ```
 
 This runs the **same builder image and checks as CI**, locally, via Docker. It needs the Docker
-daemon: if it says the daemon is unreachable, run `colima start` and retry. It does not touch
+daemon: if it says the daemon is unreachable, run `colima start --memory 8` and retry (the builder
+needs the 8GiB; the default 2GiB VM OOM-kills it). It does not touch
 Gradle or `build/`, so it is always safe to run even when the refactorer holds the project lock.
 If it fails, fix the pages and rerun until it passes; a report with this check failing is not
 done.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,19 +3,21 @@ name: Docs
 on:
   push:
     branches: [main]
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
   workflow_dispatch:
 
 permissions:
   contents: read
-  id-token: write
-  pages: write
 
 env:
   INSTANCE: docs/knn
 
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  group: docs-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -64,6 +66,14 @@ jobs:
           instance: ${{ env.INSTANCE }}
 
   deploy:
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      id-token: write
+      pages: write
+    concurrency:
+      group: pages
+      cancel-in-progress: false
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/docs/topics/enums.md
+++ b/docs/topics/enums.md
@@ -254,7 +254,7 @@ public static global::TestLibrary.Cat.Mood? napMood(int hour)
 }
 ```
 
-### Using it from C#
+### Using it from C# {id="using-it-from-c_1"}
 
 From `IntegrationTests/NullableEnumTests.cs`:
 

--- a/docs/topics/value-classes.md
+++ b/docs/topics/value-classes.md
@@ -361,7 +361,7 @@ public fun export_patient_retag(
 }
 ```
 
-### Using it from C#
+### Using it from C# {id="using-it-from-c_1"}
 
 From `IntegrationTests/ValueClassParameterTests.cs`:
 
@@ -431,7 +431,7 @@ data class ChartEntry(val id: ChartId, val note: String) {
 }
 ```
 
-### Generated C#
+### Generated C# {id="generated-c_4"}
 
 `ChartEntry.id` is `val`, so it renders as a get-only property. `Patient.currentChart` is `var`, so it
 renders with a setter too. From `Interop.cs`:
@@ -471,7 +471,7 @@ public ChartId CurrentChart
 }
 ```
 
-### Using it from C#
+### Using it from C# {id="using-it-from-c_4"}
 
 From `IntegrationTests/ValueClassPropertyTests.cs`:
 
@@ -587,7 +587,7 @@ public ChartId? PreviousChart()
 }
 ```
 
-### Using it from C#
+### Using it from C# {id="using-it-from-c_5"}
 
 From `IntegrationTests/ValueClassNullableTests.cs`:
 
@@ -796,7 +796,7 @@ public ChartRef? BackupReferral
 a has-value channel rather than a null pointer: see [Nullable over Primitive and Enum
 underlyings](#nullable-over-primitive-and-enum-underlyings) below.
 
-### Using it from C#
+### Using it from C# {id="using-it-from-c_6"}
 
 From `IntegrationTests/ValueClassUnderlyingTests.cs`:
 

--- a/scripts/verify-docs.sh
+++ b/scripts/verify-docs.sh
@@ -7,7 +7,9 @@ set -euo pipefail
 # builder's report.json, which is what writerside-checker-action does in CI.
 #
 # Needs a Docker daemon. On this repo's dev machines that is colima:
-#   brew install colima docker && colima start
+#   brew install colima docker && colima start --memory 8
+# The builder is a headless IntelliJ; colima's default 2GiB VM gets it
+# OOM-killed mid-build. 8GiB is known good and colima remembers the setting.
 # The first run pulls the builder image (several GB); later runs are quick.
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -18,29 +20,32 @@ INSTANCE="docs/knn"
 IMAGE="registry.jetbrains.team/p/writerside/builder/writerside-builder:232.10275"
 
 if ! command -v docker >/dev/null 2>&1; then
-  echo "docker CLI not found. Install it with: brew install colima docker && colima start" >&2
+  echo "docker CLI not found. Install it with: brew install colima docker && colima start --memory 8" >&2
   exit 1
 fi
 if ! docker info >/dev/null 2>&1; then
-  echo "Docker daemon not reachable. Start it with: colima start" >&2
+  echo "Docker daemon not reachable. Start it with: colima start --memory 8" >&2
   exit 1
 fi
 
-OUT="$(mktemp -d)"
+# Must live under $HOME: colima only shares $HOME with the VM, so a
+# /var/folders mktemp dir would silently mount as an empty VM-local dir.
+OUT="$(mktemp -d "$HOME/.cache/verify-docs.XXXXXX")"
 trap 'rm -rf "$OUT"' EXIT
 
 echo "==> Building Writerside instance $INSTANCE with $IMAGE"
 docker run --rm \
   -v "$ROOT":/opt/sources \
-  -v "$OUT":/opt/target \
+  -v "$OUT":/opt/out \
   "$IMAGE" \
   /bin/bash -c "
     export DISPLAY=:99
     Xvfb :99 >/dev/null 2>&1 &
     git config --global --add safe.directory /opt/sources >/dev/null 2>&1 || true
-    /opt/builder/bin/idea.sh helpbuilderinspect -source-dir /opt/sources -product $INSTANCE --runner github -output-dir /opt/target/ || true
+    /opt/builder/bin/idea.sh helpbuilderinspect -source-dir /opt/sources -product $INSTANCE --runner github -output-dir /opt/out/artifacts/ || true
   "
 
+OUT="$OUT/artifacts"
 if [ ! -f "$OUT/report.json" ]; then
   echo "docs check FAILED: builder produced no report.json (build did not run to completion)" >&2
   ls -la "$OUT" >&2 || true
@@ -54,43 +59,22 @@ import sys
 with open(sys.argv[1]) as f:
     report = json.load(f)
 
-# The report nests problems per file/check; walk it and pick up anything
-# carrying a severity, the same set writerside-checker-action reports.
-problems = []
-def walk(node):
-    if isinstance(node, dict):
-        if "severity" in node:
-            problems.append(node)
-        for value in node.values():
-            walk(value)
-    elif isinstance(node, list):
-        for value in node:
-            walk(value)
-walk(report)
+# report.json shape: testsErrors / testsWarnings map a problem id (e.g. MRK003)
+# to a list of {problemId, name, description}; counts live in testsErrorsCount,
+# testsWarningsCount, testsTotal.
+def emit(bucket, label):
+    count = 0
+    for problem_id, problems in sorted((report.get(bucket) or {}).items()):
+        for problem in problems:
+            print(f"{label}: {problem_id}: {problem.get('name', '')}: {problem.get('description', '')}")
+            count += 1
+    return count
 
-def describe(problem):
-    parts = []
-    for key in ("code", "id", "type"):
-        if problem.get(key):
-            parts.append(str(problem[key]))
-            break
-    for key in ("title", "message", "description", "text"):
-        if problem.get(key):
-            parts.append(str(problem[key]))
-            break
-    for key in ("file", "path", "location"):
-        if problem.get(key):
-            parts.append(str(problem[key]))
-            break
-    return ": ".join(parts) or json.dumps(problem)
-
-errors = [p for p in problems if str(p.get("severity", "")).upper() in ("ERROR", "FATAL")]
-for problem in problems:
-    label = "ERROR" if problem in errors else str(problem.get("severity", "INFO")).upper()
-    print(f"{label}: {describe(problem)}")
+warnings = emit("testsWarnings", "WARNING")
+errors = emit("testsErrors", "ERROR")
 
 if errors:
-    print(f"\ndocs check FAILED: {len(errors)} error(s)")
+    print(f"\ndocs check FAILED: {errors} error(s)")
     sys.exit(1)
-print("docs check passed")
+print(f"docs check passed: {report.get('testsTotal')} checks, {warnings} warning(s)")
 EOF

--- a/scripts/verify-docs.sh
+++ b/scripts/verify-docs.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Runs the real Writerside build-time checks locally: the same builder image and
+# invocation as the Docs CI (.github/workflows/docs.yml via
+# JetBrains/writerside-github-action@v4), then fails on any ERROR in the
+# builder's report.json, which is what writerside-checker-action does in CI.
+#
+# Needs a Docker daemon. On this repo's dev machines that is colima:
+#   brew install colima docker && colima start
+# The first run pulls the builder image (several GB); later runs are quick.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+INSTANCE="docs/knn"
+# Default image of writerside-github-action@v4; keep in lockstep with CI.
+IMAGE="registry.jetbrains.team/p/writerside/builder/writerside-builder:232.10275"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker CLI not found. Install it with: brew install colima docker && colima start" >&2
+  exit 1
+fi
+if ! docker info >/dev/null 2>&1; then
+  echo "Docker daemon not reachable. Start it with: colima start" >&2
+  exit 1
+fi
+
+OUT="$(mktemp -d)"
+trap 'rm -rf "$OUT"' EXIT
+
+echo "==> Building Writerside instance $INSTANCE with $IMAGE"
+docker run --rm \
+  -v "$ROOT":/opt/sources \
+  -v "$OUT":/opt/target \
+  "$IMAGE" \
+  /bin/bash -c "
+    export DISPLAY=:99
+    Xvfb :99 >/dev/null 2>&1 &
+    git config --global --add safe.directory /opt/sources >/dev/null 2>&1 || true
+    /opt/builder/bin/idea.sh helpbuilderinspect -source-dir /opt/sources -product $INSTANCE --runner github -output-dir /opt/target/ || true
+  "
+
+if [ ! -f "$OUT/report.json" ]; then
+  echo "docs check FAILED: builder produced no report.json (build did not run to completion)" >&2
+  ls -la "$OUT" >&2 || true
+  exit 1
+fi
+
+python3 - "$OUT/report.json" <<'EOF'
+import json
+import sys
+
+with open(sys.argv[1]) as f:
+    report = json.load(f)
+
+# The report nests problems per file/check; walk it and pick up anything
+# carrying a severity, the same set writerside-checker-action reports.
+problems = []
+def walk(node):
+    if isinstance(node, dict):
+        if "severity" in node:
+            problems.append(node)
+        for value in node.values():
+            walk(value)
+    elif isinstance(node, list):
+        for value in node:
+            walk(value)
+walk(report)
+
+def describe(problem):
+    parts = []
+    for key in ("code", "id", "type"):
+        if problem.get(key):
+            parts.append(str(problem[key]))
+            break
+    for key in ("title", "message", "description", "text"):
+        if problem.get(key):
+            parts.append(str(problem[key]))
+            break
+    for key in ("file", "path", "location"):
+        if problem.get(key):
+            parts.append(str(problem[key]))
+            break
+    return ": ".join(parts) or json.dumps(problem)
+
+errors = [p for p in problems if str(p.get("severity", "")).upper() in ("ERROR", "FATAL")]
+for problem in problems:
+    label = "ERROR" if problem in errors else str(problem.get("severity", "INFO")).upper()
+    print(f"{label}: {describe(problem)}")
+
+if errors:
+    print(f"\ndocs check FAILED: {len(errors)} error(s)")
+    sys.exit(1)
+print("docs check passed")
+EOF


### PR DESCRIPTION
The Docs workflow only runs on push to `main`, so docs errors land before anyone sees them; it's been red since the Phase 13 batch reused section headings and collided their Writerside ids (MRK003 in `value-classes.md` and `enums.md`). This adds the PR trigger, a local `scripts/verify-docs.sh` running the same builder image as CI via docker/colima, and fixes the collisions with explicit `{id=...}` per the files' existing convention.

Sharp edges: the local script needs `colima start --memory 8` (the default 2GiB VM OOM-kills the headless IntelliJ builder) and takes 3-5 minutes per run against CI's 1-2; the temp dir must live under `$HOME` because colima only mounts `$HOME` into the VM, which is why a plain `mktemp -d` silently produced an empty mount.

`scripts/verify-docs.sh`: reproduced main's exact 3 MRK003 errors before the fix, then `docs check passed: 166 checks, 1 warning(s)` after (the warning is the pre-existing missing `icon_dark.svg`).

- [x] Run Writerside checks on PRs and locally
- [x] Fix verify-docs.sh output mount and report parsing
- [x] Fix duplicate Writerside ids in value-classes and enums docs