### PR TITLE
Name the full include line in scope hints and warn when scoping admits nothing (#55)

### DIFF
--- a/docs/adr/063-forward-declaration-level-export-scoping.md
+++ b/docs/adr/063-forward-declaration-level-export-scoping.md
@@ -353,6 +353,16 @@ from the already-filtered `allDeclarations`.
 
 ## Consequences
 
+> **Amendment (2026-09-04, refs [#55](https://github.com/xxfast/kotlin-native-nuget/issues/55)):**
+> the replacement rule stands, but two things around it made it a trap. The
+> `SKIPPED_UNEXPORTED_DEPENDENCY_TYPE` hint (ADR-066) named only the missing package, so following
+> `add include("kotlin")` replaced the scope with one nothing in the module lives under, and the
+> processor then returned silently: green `packNuget`, no `Interop.cs`. The hint now names the full
+> `include(...)` line with the current scope kept in it, suggests nothing at all for a `kotlin.*` /
+> `kotlinx.*` type (a stdlib type wants a first-class mapping, not a scope change), and a scope that
+> admits none of the module's public declarations warns once with `SKIPPED_ALL_DECLARATIONS`.
+
+
 - **New DSL surface:** `include`/`exclude` on `NugetPublishConfig`.
 - **`rootPackage` now scopes, not just renames.** When set with no explicit `include`, only packages
   under `rootPackage` are bridged. This is a **behaviour change**: an existing consumer that sets

--- a/docs/topics/forward-overview.md
+++ b/docs/topics/forward-overview.md
@@ -189,9 +189,27 @@ outside the effective `include`/`rootPackage` scope is skipped, naming the exact
 
 ```
 [nuget:SKIPPED_UNEXPORTED_DEPENDENCY_TYPE] Skipping Newsroom.sponsor: its UNEXPORTED_DEPENDENCY_TYPE
-    type combination is not supported. add include("dev.other.core") to nuget { publish { } }, or
-    expose a type from an in-scope package instead
+    type combination is not supported. add include("io.github.xxfast.kotlin.native.nuget.test",
+    "dev.other.core") to nuget { publish { } } (an explicit include replaces the rootPackage default,
+    so keep your own packages listed), or expose a type from an in-scope package instead
     at Newsroom.kt:63
+```
+
+The hint names the whole `include(...)` line, the current scope first, because an explicit `include`
+replaces the `rootPackage` default rather than adding to it ([#55](https://github.com/xxfast/kotlin-native-nuget/issues/55)).
+A `kotlin.*`/`kotlinx.*` type gets no `include(...)` suggestion at all: a stdlib type wants a
+first-class mapping, not an export-scope change, and the hint says so.
+
+When the scope admits none of the module's public declarations, the processor warns once with
+`SKIPPED_ALL_DECLARATIONS`, naming the scope and the packages it dropped, instead of returning
+silently with no `Interop.cs` in the package:
+
+```
+[nuget:SKIPPED_ALL_DECLARATIONS] Skipping DemoNative: the export scope (include("kotlin"),
+    rootPackage = "sample") admits none of the module's 3 public declaration(s) in package(s)
+    "sample", so no Interop.cs is generated. an explicit include replaces the rootPackage default
+    rather than adding to it: list your own package(s) in include(...) as well, or drop include(...)
+    to fall back to rootPackage
 ```
 
 When at least one dependency-module type *is* admitted, the closure also emits one aggregate
@@ -250,7 +268,7 @@ repository's own fixture, KSP task `UP-TO-DATE`:
 
 > Task :test-library:nugetReportDiagnostics
 [nuget:INFO_EXPORTED_FROM_DEPENDENCY] Note TestLibraryNative: the export closure admitted 6 type(s) from dependency modules: io.github.xxfast.kotlin.native.nuget.test.models.Byline, io.github.xxfast.kotlin.native.nuget.test.models.Purr, io.github.xxfast.kotlin.native.nuget.test.models.StoryCode, io.github.xxfast.kotlin.native.nuget.test.models.StoryUri, io.github.xxfast.kotlin.native.nuget.test.models.TopStory, io.github.xxfast.kotlin.native.nuget.test.models.Whisker. these are generated exactly like module-local types; narrow with exclude(...) if any of them should not be part of the public API
-[nuget:SKIPPED_UNEXPORTED_DEPENDENCY_TYPE] Skipping io.github.xxfast.kotlin.native.nuget.test.Newsroom.sponsor: its UNEXPORTED_DEPENDENCY_TYPE type combination is not supported. add include("dev.other.core") to nuget { publish { } }, or expose a type from an in-scope package instead
+[nuget:SKIPPED_UNEXPORTED_DEPENDENCY_TYPE] Skipping io.github.xxfast.kotlin.native.nuget.test.Newsroom.sponsor: its UNEXPORTED_DEPENDENCY_TYPE type combination is not supported. add include("io.github.xxfast.kotlin.native.nuget.test", "dev.other.core") to nuget { publish { } } (an explicit include replaces the rootPackage default, so keep your own packages listed), or expose a type from an in-scope package instead
     at /Users/xxfast/Developer/XXFAST/KMP/kotlin-native-nuget/test-library/src/nativeMain/kotlin/io/github/xxfast/kotlin/native/nuget/test/Newsroom.kt:63
 [nuget:SKIPPED_INHERITED_MEMBER] Skipping io.github.xxfast.kotlin.native.nuget.test.models.StoryUri.length: its INHERITED_MEMBER type combination is not supported. declare the member directly on the value class itself instead of relying on interface delegation
 [nuget:SKIPPED_INHERITED_MEMBER] Skipping io.github.xxfast.kotlin.native.nuget.test.models.StoryUri.get: its INHERITED_MEMBER type combination is not supported. declare the member directly on the value class itself instead of relying on interface delegation

--- a/docs/topics/nuget-dsl.md
+++ b/docs/topics/nuget-dsl.md
@@ -148,6 +148,13 @@ set, otherwise to everything (today's behaviour with no scoping configured at al
 <code>rootPackage</code> is no longer bridged unless named explicitly in <code>include</code>.</p>
 </note>
 
+The corollary is that a bare `include("kotlin")` bridges nothing, since nothing in your module lives
+under `kotlin`. That used to be silent: `packNuget` stayed green and shipped a package with no
+`Interop.cs`. Since [#55](https://github.com/xxfast/kotlin-native-nuget/issues/55) a scope that admits
+none of the module's public declarations warns once with `SKIPPED_ALL_DECLARATIONS`, naming the scope
+and the packages it dropped, and every `include(...)` hint names the full line with your own packages
+kept in it.
+
 A package that is only reached via `dependencies { dependency(...) { bind { } } }` (the reverse
 stub packages generated for a consumed C# dependency) is always exported regardless of `include`/
 `exclude`, since a module that both publishes forward and consumes a NuGet dependency needs those
@@ -180,7 +187,8 @@ nuget {
 ```
 
 A reachable dependency-module type whose package falls outside the effective include set is skipped
-with `SKIPPED_UNEXPORTED_DEPENDENCY_TYPE`, naming the exact `include(...)` line that would admit it,
+with `SKIPPED_UNEXPORTED_DEPENDENCY_TYPE`, naming the full `include(...)` line that would admit it
+(the current scope first, since an explicit `include` replaces the `rootPackage` default),
 rather than silently dropping the member or leaking an unusable handle. When at least one type is
 admitted from a dependency module, the processor also emits one `INFO_EXPORTED_FROM_DEPENDENCY` line
 per KSP run, naming the whole admitted set, since a per-type warning would be noise at this scale.

--- a/nuget-processor/src/main/kotlin/io/github/xxfast/kotlin/native/nuget/processor/NugetProcessor.kt
+++ b/nuget-processor/src/main/kotlin/io/github/xxfast/kotlin/native/nuget/processor/NugetProcessor.kt
@@ -114,6 +114,8 @@ import io.github.xxfast.kotlin.native.nuget.processor.forward.toDiagnosticKind
 internal fun warnDroppedForwardCallables(
   catalog: ForwardCallablePlanCatalog,
   logger: KSPLogger,
+  // Issue #55: the effective include set, so an `include(...)` hint can name the whole line.
+  scope: List<String> = emptyList(),
 ) {
   val diagnostics: List<ForwardDiagnostic> = catalog.droppedCallables.map { dropped ->
     ForwardDiagnostic(
@@ -121,7 +123,7 @@ internal fun warnDroppedForwardCallables(
       symbol = dropped.node,
       declaration = dropped.symbol,
       reason = "its ${dropped.reason} type combination is not supported",
-      hint = dropped.reason.diagnosticHint(dropped.detail),
+      hint = dropped.reason.diagnosticHint(dropped.detail, scope),
     )
   }
   ForwardDiagnosticSink.emit(diagnostics, logger)
@@ -273,15 +275,53 @@ class NugetProcessor(
       .flatMap { it.declarations }
       .toList()
 
-    val allDeclarations: List<KSDeclaration> = allFilesDeclarations
+    val candidateDeclarations: List<KSDeclaration> = allFilesDeclarations
       .filter { it.packageName.asString() != "io.github.xxfast.kotlin.native.nuget.generated" }
       // ADR-074: the `actual` is the export root. Without this every pair is planned twice under
       // one qualified name and trips a catalog duplicate guard. Same rule, same three declaration
       // kinds, as Kotlin/Native's own C export (`CAdapterGenerator`) and ObjC export. No
       // diagnostic: filtering an `expect` is normal and every Kotlin backend does it silently.
       .filter { !it.isExpect }
-      .filter { isPackageExported(it.packageName.asString()) }
       .toList()
+
+    val allDeclarations: List<KSDeclaration> = candidateDeclarations
+      .filter { isPackageExported(it.packageName.asString()) }
+
+    // Issue #55: scoping that admits nothing used to be indistinguishable from a module with no
+    // public API at all: `packNuget` stayed green with no `Interop.cs` in the package. Say so
+    // once, naming the scope that did it, before the `hasNothingToProcess` early return below.
+    if (allDeclarations.isEmpty() && candidateDeclarations.isNotEmpty()) {
+      val scope: String = buildList {
+        if (context.includePackages.isNotEmpty()) {
+          add("include(${context.includePackages.joinToString { "\"$it\"" }})")
+        }
+        if (context.excludePackages.isNotEmpty()) {
+          add("exclude(${context.excludePackages.joinToString { "\"$it\"" }})")
+        }
+        if (context.rootPackage.isNotBlank()) add("rootPackage = \"${context.rootPackage}\"")
+      }.joinToString()
+      val packages: String = candidateDeclarations
+        .map { it.packageName.asString() }
+        .distinct()
+        .sorted()
+        .joinToString { "\"$it\"" }
+      ForwardDiagnosticSink.emit(
+        listOf(
+          ForwardDiagnostic(
+            kind = ForwardDiagnosticKind.SKIPPED_ALL_DECLARATIONS,
+            symbol = null,
+            declaration = context.libraryName,
+            reason = "the export scope ($scope) admits none of the module's " +
+                "${candidateDeclarations.size} public declaration(s) in package(s) $packages, " +
+                "so no Interop.cs is generated",
+            hint = "an explicit include replaces the rootPackage default rather than adding to " +
+                "it: list your own package(s) in include(...) as well, or drop include(...) to " +
+                "fall back to rootPackage",
+          ),
+        ),
+        logger,
+      )
+    }
 
     // ADR-074: kept because the `actual` is structurally complete but metadata-poor (no KDoc, no
     // annotations, no parameter defaults). `findExpects()` is Verified empty on KSP 2.3.10, so the
@@ -460,7 +500,12 @@ class NugetProcessor(
         interfaces.isEmpty() && sealedClasses.isEmpty() && objects.isEmpty() &&
         properties.isEmpty() && constProperties.isEmpty() && valueClasses.isEmpty() &&
         suspendFunctions.isEmpty()
-    if (hasNothingToProcess) return emptyList()
+    if (hasNothingToProcess) {
+      // Issue #55: the diagnostics file is what `nugetReportDiagnostics` re-emits, so the
+      // SKIPPED_ALL_DECLARATIONS warning above has to reach it even though nothing else is written.
+      writeForwardDiagnostics(Dependencies.ALL_FILES)
+      return emptyList()
+    }
 
     // This processor is whole-module by construction: every round rescans
     // resolver.getAllFiles() and rewrites one Interop.cs and one CNameExports.kt from
@@ -545,7 +590,7 @@ class NugetProcessor(
           forwardPropertyPlanner.droppedExtensionReceivers,
     )
 
-    warnDroppedForwardCallables(callableCatalog, logger)
+    warnDroppedForwardCallables(callableCatalog, logger, effectiveInclude)
     warnDroppedForwardPropertySetters(callableCatalog, logger)
     warnDroppedForwardProperties(callableCatalog, logger)
     warnDroppedForwardExtensionReceivers(callableCatalog, logger)

--- a/nuget-processor/src/main/kotlin/io/github/xxfast/kotlin/native/nuget/processor/forward/ForwardDiagnostic.kt
+++ b/nuget-processor/src/main/kotlin/io/github/xxfast/kotlin/native/nuget/processor/forward/ForwardDiagnostic.kt
@@ -109,6 +109,14 @@ internal enum class ForwardDiagnosticKind(val severity: ForwardDiagnosticSeverit
    *  [SKIPPED_UNEXPORTED_DEPENDENCY_TYPE] does: the ADR-066 closure has no `superTypes` edge, so
    *  admitting the package cannot pull a supertype-only interface in. */
   SKIPPED_UNEXPORTED_SUPERTYPE(ForwardDiagnosticSeverity.WARNING),
+
+  /** Issue #55: the module has public declarations, but the `include`/`exclude`/`rootPackage`
+   *  scope (ADR-063) admits none of them, so no `Interop.cs` is generated at all. Without this
+   *  the build stays green and the package still packs, with its whole C# surface silently
+   *  missing: the trap a bare `include("kotlin")` walks into, since an explicit `include`
+   *  replaces the `rootPackage` default rather than adding to it. Emitted once per KSP run,
+   *  with no source location (the scope is build configuration, not a declaration). */
+  SKIPPED_ALL_DECLARATIONS(ForwardDiagnosticSeverity.WARNING),
 }
 
 /**
@@ -242,13 +250,34 @@ internal fun ForwardPlanSkipReason.toDiagnosticKind(): ForwardDiagnosticKind = w
  *   carries the offending component ("element type Collection?", "key type String?"). Ignored by
  *   every other reason.
  */
-internal fun ForwardPlanSkipReason.diagnosticHint(detail: String? = null): String = when (this) {
+/** `kotlin`, `kotlin.*` and `kotlinx.*`: packages an export scope can never usefully admit. */
+private fun String.isStdlibPackage(): Boolean =
+  this == "kotlin" || startsWith("kotlin.") || this == "kotlinx" || startsWith("kotlinx.")
+
+internal fun ForwardPlanSkipReason.diagnosticHint(
+  detail: String? = null,
+  scope: List<String> = emptyList(),
+): String = when (this) {
   ForwardPlanSkipReason.UNEXPORTED_DEPENDENCY_TYPE -> {
     val dependencyPackage: String = detail
       ?.let { qualifiedName -> qualifiedName.substringBeforeLast('.', qualifiedName) }
       ?: "the dependency's package"
-    "add include(\"$dependencyPackage\") to nuget { publish { } }, or expose a type from an " +
-        "in-scope package instead"
+    if (dependencyPackage.isStdlibPackage()) {
+      // Issue #55/#56: `include("kotlin")` was the hint here, and following it replaced the
+      // export scope with one nothing in the module lives under. A stdlib type wants a first-class
+      // mapping (ADR-076 `Instant`, ADR-103 `Duration`), not an export-scope change.
+      "${detail ?: "it"} is a Kotlin stdlib type with no first-class C# mapping yet; expose a " +
+          "bridgeable type instead (include(...) is not the fix: an explicit include replaces " +
+          "the export scope rather than mapping the type)"
+    } else {
+      // Issue #55: name the whole include line, not just the missing package. ADR-063's explicit
+      // `include` replaces the `rootPackage` default, so a hint naming only the new package
+      // walks the author into an empty export set.
+      val packages: String = (scope + dependencyPackage).distinct().joinToString { "\"$it\"" }
+      "add include($packages) to nuget { publish { } } (an explicit include replaces the " +
+          "rootPackage default, so keep your own packages listed), or expose a type from an " +
+          "in-scope package instead"
+    }
   }
 
   ForwardPlanSkipReason.ACTUAL_TYPEALIAS_TARGET -> {

--- a/nuget-processor/src/test/kotlin/io/github/xxfast/kotlin/native/nuget/processor/tier1/Tier1ExportScopeDiagnosticsTest.kt
+++ b/nuget-processor/src/test/kotlin/io/github/xxfast/kotlin/native/nuget/processor/tier1/Tier1ExportScopeDiagnosticsTest.kt
@@ -1,0 +1,167 @@
+package io.github.xxfast.kotlin.native.nuget.processor.tier1
+
+import io.github.xxfast.kotlin.native.nuget.processor.forward.ForwardDiagnosticKind
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Issue #55: an explicit `include(...)` replaces the `rootPackage` default (ADR-063, deliberate),
+ * and two things around that rule made it a trap. The `SKIPPED_UNEXPORTED_DEPENDENCY_TYPE` hint
+ * named only the missing package, so following it emptied the export set; and an empty export set
+ * returned silently, leaving a green `packNuget` with no `Interop.cs` in the package.
+ */
+class Tier1ExportScopeDiagnosticsTest {
+
+  private val dependencyJar: File = Tier1DependencyLibrary.compile(
+    """
+    package dep.outside
+
+    class Advert(val sponsor: String)
+    """.trimIndent(),
+    fileName = "Advert.kt",
+  )
+
+  @Test
+  fun `the include hint lists the explicit include set ahead of the missing package`() {
+    val result = Tier1Harness.run(
+      """
+      package tier1.scopehint.api
+
+      import dep.outside.Advert
+
+      class Newsroom {
+        fun sponsor(): Advert = Advert("Acme")
+      }
+      """.trimIndent(),
+      processorOptions = mapOf(
+        "nuget.rootPackage" to "tier1.scopehint",
+        "nuget.includePackages" to "tier1.scopehint.api",
+      ),
+      libraries = listOf(dependencyJar),
+    )
+
+    val diagnostic: String = requireNotNull(
+      result.kspWarnings.firstOrNull {
+        it.contains(ForwardDiagnosticKind.SKIPPED_UNEXPORTED_DEPENDENCY_TYPE.name)
+      },
+    ) {
+      "expected a SKIPPED_UNEXPORTED_DEPENDENCY_TYPE diagnostic; kspWarnings=${result.kspWarnings}"
+    }
+    assertTrue(
+      diagnostic.contains("include(\"tier1.scopehint.api\", \"dep.outside\")"),
+      "expected the hint to name the full include line; got: $diagnostic",
+    )
+    assertTrue(
+      diagnostic.contains("replaces the rootPackage default"),
+      "expected the hint to say why the own package must stay listed; got: $diagnostic",
+    )
+  }
+
+  @Test
+  fun `a stdlib type gets no include hint at all`() {
+    val result = Tier1Harness.run(
+      """
+      package tier1.scopehint
+
+      import kotlin.uuid.ExperimentalUuidApi
+      import kotlin.uuid.Uuid
+
+      @OptIn(ExperimentalUuidApi::class)
+      class Record(val id: Uuid)
+
+      @OptIn(ExperimentalUuidApi::class)
+      fun record(): Record = Record(Uuid.random())
+      """.trimIndent(),
+      processorOptions = mapOf("nuget.rootPackage" to "tier1.scopehint"),
+    )
+
+    val diagnostic: String = requireNotNull(
+      result.kspWarnings.firstOrNull {
+        it.contains(ForwardDiagnosticKind.SKIPPED_UNEXPORTED_DEPENDENCY_TYPE.name)
+      },
+    ) {
+      "expected a SKIPPED_UNEXPORTED_DEPENDENCY_TYPE diagnostic; kspWarnings=${result.kspWarnings}"
+    }
+    assertFalse(
+      diagnostic.contains("add include("),
+      "expected no include(...) suggestion for a stdlib type; got: $diagnostic",
+    )
+    assertTrue(
+      diagnostic.contains("kotlin.uuid.Uuid is a Kotlin stdlib type"),
+      "expected the hint to name the stdlib type; got: $diagnostic",
+    )
+  }
+
+  @Test
+  fun `an include that admits nothing warns once instead of returning silently`() {
+    val result = Tier1Harness.run(
+      """
+      package tier1.scopehint
+
+      class Holder(val name: String)
+
+      fun holder(): Holder = Holder("Oreo")
+      """.trimIndent(),
+      processorOptions = mapOf(
+        "nuget.rootPackage" to "tier1.scopehint",
+        "nuget.includePackages" to "kotlin",
+      ),
+    )
+
+    val warnings: List<String> = result.kspWarnings.filter {
+      it.contains(ForwardDiagnosticKind.SKIPPED_ALL_DECLARATIONS.name)
+    }
+    assertTrue(
+      warnings.size == 1,
+      "expected exactly one SKIPPED_ALL_DECLARATIONS; got: ${result.kspWarnings}",
+    )
+    val warning: String = warnings.single()
+    assertTrue(warning.contains("include(\"kotlin\")"), "expected the scope named; got: $warning")
+    assertTrue(
+      warning.contains("rootPackage = \"tier1.scopehint\""),
+      "expected rootPackage named; got: $warning",
+    )
+    assertTrue(
+      warning.contains("\"tier1.scopehint\""),
+      "expected the skipped package named; got: $warning",
+    )
+    assertTrue(
+      warning.contains("replaces the rootPackage default"),
+      "expected the hint to explain the replacement rule; got: $warning",
+    )
+    assertFalse(
+      result.generatedFiles.keys.any { it.endsWith("Interop.cs") },
+      "expected no Interop.cs; generatedFiles=${result.generatedFiles.keys}",
+    )
+    assertTrue(
+      result.generatedFiles.keys.any { it.endsWith("NugetDiagnostics.json") },
+      "expected the diagnostics file to still be written so nugetReportDiagnostics can re-emit " +
+          "the warning; generatedFiles=${result.generatedFiles.keys}",
+    )
+    assertTrue(
+      result.generatedFiles.entries.single { it.key.endsWith("NugetDiagnostics.json") }.value
+        .contains(ForwardDiagnosticKind.SKIPPED_ALL_DECLARATIONS.name),
+      "expected the warning inside NugetDiagnostics.json",
+    )
+  }
+
+  @Test
+  fun `a module with no public declarations at all does not warn`() {
+    val result = Tier1Harness.run(
+      """
+      package tier1.scopehint
+
+      internal class Hidden(val name: String)
+      """.trimIndent(),
+      processorOptions = mapOf("nuget.rootPackage" to "tier1.scopehint"),
+    )
+
+    assertFalse(
+      result.kspWarnings.any { it.contains(ForwardDiagnosticKind.SKIPPED_ALL_DECLARATIONS.name) },
+      "expected no SKIPPED_ALL_DECLARATIONS when scoping removed nothing; " +
+          "got: ${result.kspWarnings}",
+    )
+  }
+}

--- a/nuget-processor/src/test/kotlin/io/github/xxfast/kotlin/native/nuget/processor/tier1/Tier1ReachabilityClosureTest.kt
+++ b/nuget-processor/src/test/kotlin/io/github/xxfast/kotlin/native/nuget/processor/tier1/Tier1ReachabilityClosureTest.kt
@@ -59,9 +59,11 @@ class Tier1ReachabilityClosureTest {
       "expected a SKIPPED_UNEXPORTED_DEPENDENCY_TYPE diagnostic naming Newsroom.sponsor's " +
           "out-of-scope dep.outside.Advert return type; kspWarnings=${result.kspWarnings}"
     }
+    // Issue #55: the hint names the whole include line, own package first, because an explicit
+    // include replaces the rootPackage default rather than adding to it.
     assertTrue(
-      diagnostic.contains("include(\"dep.outside\")"),
-      "expected the diagnostic to name the exact include(\"dep.outside\") fix; got: $diagnostic",
+      diagnostic.contains("include(\"tier1.reachabilityclosure\", \"dep.outside\")"),
+      "expected the diagnostic to name the full include(...) line; got: $diagnostic",
     )
   }
 


### PR DESCRIPTION
ADR-063's replacement rule is deliberate and stays: an explicit `include` replaces the `rootPackage` default, mirroring the reverse side's `bind { include }`. Two things around it made it a trap. The `SKIPPED_UNEXPORTED_DEPENDENCY_TYPE` hint named only the missing package, so following `add include("kotlin")` replaced the scope with one nothing in the module lives under, and the processor then returned silently from `hasNothingToProcess`: green `packNuget`, no `Interop.cs`.

```
[nuget:SKIPPED_UNEXPORTED_DEPENDENCY_TYPE] Skipping Newsroom.sponsor: ... add include("io.github.xxfast.kotlin.native.nuget.test", "dev.other.core") to nuget { publish { } } (an explicit include replaces the rootPackage default, so keep your own packages listed), or expose a type from an in-scope package instead

[nuget:SKIPPED_ALL_DECLARATIONS] Skipping DemoNative: the export scope (include("kotlin"), rootPackage = "sample") admits none of the module's 3 public declaration(s) in package(s) "sample", so no Interop.cs is generated. an explicit include replaces the rootPackage default rather than adding to it: list your own package(s) in include(...) as well, or drop include(...) to fall back to rootPackage
```

A `kotlin.*`/`kotlinx.*` type now gets no `include(...)` suggestion at all; the hint says it wants a first-class mapping instead (that's #56's territory). The new warning has no source location on purpose, the scope is build config, and the diagnostics JSON is now written on the early-return path too, otherwise `nugetReportDiagnostics` would never see it. ADR-063 carries an amendment note under Consequences rather than a new ADR.

`scripts/verify.sh` green: 1148 passed, 0 skipped, 0 failed.

- [x] Name the full include line in scope hints and warn when scoping admits nothing (#55)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVrRf1PUgTPeaXYADtfKFG