### PR TITLE
Let exclude() name a qualified declaration, not only a package (#53)

### DIFF
--- a/docs/adr/063-forward-declaration-level-export-scoping.md
+++ b/docs/adr/063-forward-declaration-level-export-scoping.md
@@ -404,3 +404,12 @@ from the already-filtered `allDeclarations`.
 - Per-declaration opt-out annotation.
 - Cross-module reachability closure (MF-003), sequenced after forward diagnostics and the
   value-class-parameter fix.
+
+> **Amendment (2026-09-04, refs [#53](https://github.com/xxfast/kotlin-native-nuget/issues/53)):**
+> `exclude(...)` was package-prefix only, matched against `packageName`, so a qualified type name
+> silently matched nothing: the only way to route around one unbridgeable member was to drop its
+> whole package. The predicate now runs over the declaration: `exclude` also matches a qualified
+> declaration name and everything nested under it (a sealed base takes its subclasses), and the
+> ADR-066 reachability closure uses the same declaration-level predicate. `include` stays
+> package-level; a per-declaration opt-in has no use case yet. The "per-declaration opt-out
+> annotation" deferred above is now partly covered from the build script side.

--- a/docs/topics/nuget-dsl.md
+++ b/docs/topics/nuget-dsl.md
@@ -29,7 +29,7 @@ the DSL itself enforces they're set, but `packNuget` fails once it reads an unse
 | `description` | `String?` | yes | `.nuspec` `<description>` |
 | `rootPackage` | `String?` | yes | the Kotlin package the generated C# namespaces are rooted at; sub-packages map relative to it. Also the default export scope: see below |
 | `include(vararg packages: String)` | function | no | empty; when set, only these package prefixes (and their sub-packages) are bridged |
-| `exclude(vararg packages: String)` | function | no | empty; applied after `include`, and always wins over it |
+| `exclude(vararg packages: String)` | function | no | empty; a package prefix or a qualified declaration name (a class, object, sealed base, or top-level function, plus everything nested under it); applied after `include`, and always wins over it |
 | `snapshot` | `Boolean` | no | `false`; when `true`, `packNuget` mints `<version>-snapshot.<epochMillis>` at execution time instead of using `version` literally, and always writes an MSBuild props file. Requires `packageId` and a non-blank `version` |
 | `versionPropsFile` | `File?` | no | `null`; only consulted when `snapshot` is `true`. Default `<rootProject>/build/<packageId>Versions.props` |
 | `prebuiltRuntimes` | `File?` | no | `null`; a directory laid out `<rid>/native/*.{dll,dylib,so}`, exactly the `runtimes/` tree `packNuget` stages, merged with the RIDs this host links itself into one package |
@@ -129,6 +129,11 @@ for the full validation semantics and the alternatives considered.
 By default `NugetProcessor` bridges every public declaration in the module. `include`/`exclude` on
 `publish {}` scope that down, mirroring `bind { include/exclude }` on the reverse side: a package
 prefix match (`pkg == p || pkg.startsWith("$p.")`), with `exclude` always winning over `include`.
+`exclude` additionally matches a qualified declaration name and everything nested under it
+([#53](https://github.com/xxfast/kotlin-native-nuget/issues/53)): `exclude("com.contoso.api.Shape")`
+drops the `Shape` class (and, for a sealed base, its subclasses) from the export set, so a member
+that references it is skipped with a named diagnostic and the rest of the package still bridges.
+`include` stays package-level.
 
 ```kotlin
 nuget {
@@ -137,6 +142,7 @@ nuget {
     rootPackage = "com.contoso.api"
     include("com.contoso.api")            // whitelist of package prefixes
     exclude("com.contoso.api.internal")   // exclude wins
+    exclude("com.contoso.api.Legacy")     // one type, by qualified name
   }
 }
 ```

--- a/nuget-processor/src/main/kotlin/io/github/xxfast/kotlin/native/nuget/processor/NugetProcessor.kt
+++ b/nuget-processor/src/main/kotlin/io/github/xxfast/kotlin/native/nuget/processor/NugetProcessor.kt
@@ -254,15 +254,22 @@ class NugetProcessor(
       else -> emptyList()
     }
 
-    fun isPackageExported(pkg: String): Boolean {
+    fun isExported(declaration: KSDeclaration): Boolean {
+      val pkg: String = declaration.packageName.asString()
+      val qualifiedName: String? = declaration.qualifiedName?.asString()
       fun matches(p: String) = pkg == p || pkg.startsWith("$p.")
+      // Issue #53: `exclude(...)` also accepts a qualified declaration name, and everything
+      // nested under it (a sealed base takes its subclasses with it). Package-level exclusion
+      // took whole packages of wanted API with it whenever one member could not be bridged.
+      fun matchesDeclaration(p: String) =
+        qualifiedName != null && (qualifiedName == p || qualifiedName.startsWith("$p."))
       // ADR-063 "Reverse-bound packages are always in scope": checked first, before exclude and
       // before include. A module that both publishes forward and consumes via `bind {}` returns
       // reverse-bound types from its own forward code; dropping the bound stub's declaration
       // while the forward-generated C# still references it is a dangling-reference build break,
       // not a scoping choice the user asked for.
       if (context.boundPackages.any(::matches)) return true
-      if (context.excludePackages.any(::matches)) return false
+      if (context.excludePackages.any { matches(it) || matchesDeclaration(it) }) return false
       if (effectiveInclude.isEmpty()) return true
       return effectiveInclude.any(::matches)
     }
@@ -284,8 +291,7 @@ class NugetProcessor(
       .filter { !it.isExpect }
       .toList()
 
-    val allDeclarations: List<KSDeclaration> = candidateDeclarations
-      .filter { isPackageExported(it.packageName.asString()) }
+    val allDeclarations: List<KSDeclaration> = candidateDeclarations.filter(::isExported)
 
     // Issue #55: scoping that admits nothing used to be indistinguishable from a module with no
     // public API at all: `packNuget` stayed green with no `Interop.cs` in the package. Say so
@@ -434,10 +440,10 @@ class NugetProcessor(
     // ADR-066: the reachability closure discovers dependency-module (klib) declarations reachable
     // from these module-local roots — the only way in, since `getDeclarationsFromPackage` returns
     // empty for a klib dependency (verified). A discovered declaration is admitted iff it passes
-    // the same `isPackageExported` predicate the roots already did, and only when the module
+    // the same `isExported` predicate the roots already did, and only when the module
     // crosses into `include`/`rootPackage` scope at all (admission rule 4).
     val reachability: ForwardReachabilityResult = ForwardReachabilityClosure(
-      isPackageExported = ::isPackageExported,
+      isExported = ::isExported,
       crossModuleAdmissionAllowed = effectiveInclude.isNotEmpty(),
       actualTypeAliasTargets = actualTypeAliasTargets,
     ).walk(

--- a/nuget-processor/src/main/kotlin/io/github/xxfast/kotlin/native/nuget/processor/forward/ForwardReachabilityClosure.kt
+++ b/nuget-processor/src/main/kotlin/io/github/xxfast/kotlin/native/nuget/processor/forward/ForwardReachabilityClosure.kt
@@ -3,6 +3,7 @@ package io.github.xxfast.kotlin.native.nuget.processor.forward
 import com.google.devtools.ksp.getVisibility
 import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSType
@@ -43,7 +44,9 @@ internal data class ForwardReachabilityResult(
  * (`A.b: B`, `B.a: A`) terminates on the second visit.
  */
 internal class ForwardReachabilityClosure(
-  private val isPackageExported: (String) -> Boolean,
+  /** ADR-063's scope predicate over the declaration itself (issue #53: `exclude` may name a
+   *  qualified declaration, not only a package), shared with the root scan. */
+  private val isExported: (KSDeclaration) -> Boolean,
   /** ADR-066 admission rule 4: with neither `rootPackage` nor `include` set, the closure must not
    *  cross the module boundary at all (or it would walk straight into `kotlinx-coroutines`). An
    *  empty effective include set means "admit everything" for the module's own files (ADR-063),
@@ -165,7 +168,7 @@ internal class ForwardReachabilityClosure(
       // `exclude(...)` package filtered out of the root scan. Only recurse when it independently
       // passes the same predicate roots already did; otherwise leave it exactly as unadmitted as
       // it already was (the classifier's existing "not in the exported object-handle set" path).
-      if (isPackageExported(classDeclaration.packageName.asString())) {
+      if (isExported(classDeclaration)) {
         walkClassMembers(classDeclaration)
       }
       return
@@ -174,7 +177,7 @@ internal class ForwardReachabilityClosure(
     // Cross-module (klib) declaration: ADR-066's admission predicate.
     if (classDeclaration.getVisibility() != Visibility.PUBLIC) return
     if (!crossModuleAdmissionAllowed) return
-    if (!isPackageExported(classDeclaration.packageName.asString())) return
+    if (!isExported(classDeclaration)) return
 
     admitted[qualifiedName] = classDeclaration
     bucketOf[qualifiedName] = classDeclaration.reachabilityBucket()

--- a/nuget-processor/src/test/kotlin/io/github/xxfast/kotlin/native/nuget/processor/tier1/Tier1TypeLevelExcludeTest.kt
+++ b/nuget-processor/src/test/kotlin/io/github/xxfast/kotlin/native/nuget/processor/tier1/Tier1TypeLevelExcludeTest.kt
@@ -1,0 +1,121 @@
+package io.github.xxfast.kotlin.native.nuget.processor.tier1
+
+import io.github.xxfast.kotlin.native.nuget.processor.forward.ForwardDiagnosticKind
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Issue #53: `exclude(...)` matched package names only, so `exclude("pkg.Shape")` changed nothing
+ * and the only working remedy for one unbridgeable member was dropping its whole package. It now
+ * also matches a qualified declaration name and everything nested under it, at the root scan and
+ * in the ADR-066 reachability closure alike. A member referencing the excluded type skips with a
+ * named diagnostic; the rest of the package still bridges.
+ */
+class Tier1TypeLevelExcludeTest {
+
+  private val fixture: String = """
+    package tier1.typeexclude
+
+    sealed class Shape {
+      data class Circle(val radius: Double) : Shape()
+    }
+
+    data class Album(val shapes: List<Shape>, val title: String)
+
+    data class Frame(val width: Int)
+
+    fun album(): Album = Album(emptyList(), "Oreo")
+
+    fun frame(): Frame = Frame(1)
+  """.trimIndent()
+
+  private fun run(vararg exclude: String): Tier1Result = Tier1Harness.run(
+    fixture,
+    processorOptions = mapOf(
+      "nuget.rootPackage" to "tier1.typeexclude",
+      "nuget.excludePackages" to exclude.joinToString(","),
+    ),
+  )
+
+  @Test
+  fun `excluding a sealed base by qualified name drops it and its subclasses only`() {
+    val result = run("tier1.typeexclude.Shape")
+
+    assertTrue(result.compiledClean, "expected a clean compile; got: ${result.compileErrors}")
+    val csharp: String = result.generatedCSharp
+    assertFalse(csharp.contains("class Shape"), "expected Shape gone; got: $csharp")
+    assertFalse(csharp.contains("class Circle"), "expected Shape.Circle gone; got: $csharp")
+    assertTrue(csharp.contains("class Album"), "expected Album kept; got: $csharp")
+    assertTrue(csharp.contains("class Frame"), "expected Frame kept; got: $csharp")
+    assertTrue(csharp.contains("string Title"), "expected Album.title kept; got: $csharp")
+    assertFalse(
+      result.generated.contains("export_album_get_shapes"),
+      "expected Album.shapes skipped, not walked; generated=${result.generated}",
+    )
+    assertTrue(
+      result.kspWarnings.any {
+        it.contains(ForwardDiagnosticKind.SKIPPED_UNSUPPORTED_PROPERTY.name) &&
+            it.contains("Album.shapes")
+      },
+      "expected a named skip for the member referencing the excluded type; " +
+          "kspWarnings=${result.kspWarnings}",
+    )
+  }
+
+  @Test
+  fun `excluding the owning type by qualified name leaves its siblings alone`() {
+    val result = run("tier1.typeexclude.Album")
+
+    assertTrue(result.compiledClean, "expected a clean compile; got: ${result.compileErrors}")
+    val csharp: String = result.generatedCSharp
+    assertFalse(csharp.contains("class Album"), "expected Album gone; got: $csharp")
+    assertTrue(csharp.contains("class Shape"), "expected Shape kept; got: $csharp")
+    assertTrue(csharp.contains("class Frame"), "expected Frame kept; got: $csharp")
+    assertTrue(
+      result.generated.contains("export_frame"),
+      "expected the top-level frame() to bind; generated=${result.generated}",
+    )
+  }
+
+  @Test
+  fun `excluding a top-level function by qualified name drops just that function`() {
+    val result = run("tier1.typeexclude.frame")
+
+    assertTrue(result.compiledClean, "expected a clean compile; got: ${result.compileErrors}")
+    assertFalse(
+      result.generated.contains("export_frame("),
+      "expected frame() gone; generated=${result.generated}",
+    )
+    assertTrue(result.generatedCSharp.contains("class Frame"), "expected the Frame class kept")
+    assertTrue(
+      result.generated.contains("export_album("),
+      "expected album() kept; generated=${result.generated}",
+    )
+  }
+
+  @Test
+  fun `a qualified name that is only a prefix of another does not exclude it`() {
+    // `tier1.typeexclude.Frame` must not take `tier1.typeexclude.FrameSet`-style names with it;
+    // the match is exact or dotted-nested, never a raw string prefix.
+    val result = Tier1Harness.run(
+      """
+      package tier1.typeexclude
+
+      data class Frame(val width: Int)
+      data class FrameSet(val frames: Int)
+      """.trimIndent(),
+      processorOptions = mapOf(
+        "nuget.rootPackage" to "tier1.typeexclude",
+        "nuget.excludePackages" to "tier1.typeexclude.Frame",
+      ),
+    )
+
+    val csharp: String = result.generatedCSharp
+    assertFalse(
+      csharp.contains("class Frame\n") || csharp.contains("class Frame "),
+      "expected Frame gone; got: $csharp",
+    )
+    assertTrue(csharp.contains("class FrameSet"), "expected FrameSet kept; got: $csharp")
+  }
+}


### PR DESCRIPTION
`exclude(...)` was matched against `packageName` only, so `exclude("sample.Shape")` silently matched nothing and the only working remedy for one unbridgeable member was dropping its whole package, wanted API and all. The scope predicate now runs over the declaration itself: `exclude` also matches a qualified declaration name and everything nested under it, at the root scan and inside the ADR-066 reachability closure, which used the same package-only predicate. `include` stays package-level; nothing asked for a per-declaration opt-in.

```kotlin
nuget { publish { rootPackage = "sample"; exclude("sample.Shape") } }

sealed class Shape { data class Circle(val radius: Double) : Shape() }
data class Album(val shapes: List<Shape>, val title: String)
```

```
[nuget:SKIPPED_UNSUPPORTED_PROPERTY] Skipping sample.Album.shapes: ...
// Interop.cs: no Shape, no Shape.Circle; Album with Title still generated
```

Matching is exact or dotted-nested, never a raw prefix: `exclude("sample.Frame")` leaves `sample.FrameSet` alone. A top-level function excludes by its qualified name too. ADR-063 carries an amendment note at the end rather than a new ADR.

`scripts/verify.sh` green: 1148 passed, 0 skipped, 0 failed.

- [x] Let exclude() name a qualified declaration, not only a package (#53)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVrRf1PUgTPeaXYADtfKFG