### PR TITLE
Prepare for release 0.5.0

### DIFF
--- a/docs/topics/prerequisites.md
+++ b/docs/topics/prerequisites.md
@@ -28,7 +28,7 @@ additional tooling.
 
 | kotlin-native-nuget | Kotlin   | KSP      | Gradle | JDK | .NET   |
 |----------------------|----------|----------|--------|-----|--------|
-| `0.2.0` – `0.4.0`    | `2.4.10` | `2.3.10` | `9.1`  | 17+ | `8.0`+ |
+| `0.2.0` – `0.5.0`    | `2.4.10` | `2.3.10` | `9.1`  | 17+ | `8.0`+ |
 | `0.1.0`              | `2.4.0`  | `2.3.9`  | `9.1`  | 17+ | `8.0`+ |
 
 KSP is pinned to its Kotlin version, so bumping Kotlin without bumping the plugin is not

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # Single source of truth for the version. The `nuget-plugin` included build does not
 # inherit these across the composite boundary, so it reads this file explicitly.
 group=io.github.xxfast
-version=0.4.0
+version=0.5.0
 
 #Kotlin
 kotlin.code.style=official


### PR DESCRIPTION
Bumps `version` to `0.5.0` in `gradle.properties` (the release workflow refuses a tag that disagrees with it) and extends the compatibility row in `docs/topics/prerequisites.md` to `0.2.0` – `0.5.0`; Kotlin `2.4.10`, KSP `2.3.10` and Gradle `9.1` are unchanged since 0.4.0.

Minor bump: since 0.4.0 main gained ADR-104 (reverse thunk error channel), ADR-105 (sealed-typed properties), ADR-106/107/108 (`Uuid`, `Throwable`, `Result<T>`), ADR-109 (duplicate dependency type warning), plus the #50 to #57 and #65/#66 fixes.

Compatibility: the `error` → `error_` rename (#66) only touches signatures that previously failed to compile, with one edge: a Kotlin parameter literally named `error_` compiled on 0.4.0 and now renders as `error__` because the rename shifts the whole `error`, `error_`, `error__` chain to stay injective. Named-argument call sites for such a parameter would need updating.

After merging: tag the squash-merge commit on `main` as `0.5.0` (no `v` prefix) to trigger `release.yml`, then create the GitHub release from the hand-built notes draft (six of the sixteen PRs were merged into stacked, non-`main` bases, so auto-generated notes may not attribute them cleanly).

`./gradlew :nuget-plugin:test` passes locally with the bumped version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JdqYK6VUwKJwmdJcuDEKrD