### PR TITLE
Export suspend lambda arities 2 and 3 so the forward ABI check passes (ADR-020)

### DIFF
--- a/IntegrationTests/SuspendLambdaTests.cs
+++ b/IntegrationTests/SuspendLambdaTests.cs
@@ -31,6 +31,43 @@ public class SuspendLambdaTests
     }
 
     [Fact]
+    public async Task CatFeeder_OnFeedPortion_Arity2_InvokeAsync_ReturnsExpectedString()
+    {
+        using var feeder = new CatFeeder("Mylo");
+        using var onFeedPortion = feeder.OnFeedPortion;
+        string result = await onFeedPortion.InvokeAsync("salmon", 40);
+        Assert.Equal("Mylo devoured 40g of salmon!", result);
+    }
+
+    [Fact]
+    public async Task CatFeeder_OnFeedSchedule_Arity3_InvokeAsync_ReturnsExpectedString()
+    {
+        using var feeder = new CatFeeder("Oreo");
+        using var onFeedSchedule = feeder.OnFeedSchedule;
+        string result = await onFeedSchedule.InvokeAsync("tuna", 25, "dawn");
+        Assert.Equal("Oreo devoured 25g of tuna at dawn!", result);
+    }
+
+    [Fact]
+    public async Task CatFeeder_OnLogMeal_Arity2Unit_InvokeAsync_CompletesWithoutError()
+    {
+        using var feeder = new CatFeeder("Oreo");
+        using var onLogMeal = feeder.OnLogMeal;
+        await onLogMeal.InvokeAsync("tuna", "dawn");
+    }
+
+    [Fact]
+    public async Task CatFeeder_OnFeedPortion_CancelViaToken_MyloLeftHungry()
+    {
+        using var feeder = new CatFeeder("Mylo");
+        using var onFeedPortion = feeder.OnFeedPortion;
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+        await Assert.ThrowsAsync<TaskCanceledException>(
+            () => onFeedPortion.InvokeAsync("salmon", 40, cts.Token));
+    }
+
+    [Fact]
     public async Task CatFeeder_OnFeed_MultipleInvocations_ReturnSameResult()
     {
         using var feeder = new CatFeeder("Mylo");

--- a/nuget-processor/src/main/kotlin/io/github/xxfast/kotlin/native/nuget/processor/NugetProcessor.kt
+++ b/nuget-processor/src/main/kotlin/io/github/xxfast/kotlin/native/nuget/processor/NugetProcessor.kt
@@ -46,8 +46,7 @@ import io.github.xxfast.kotlin.native.nuget.processor.exports.addNugetFunc0Helpe
 import io.github.xxfast.kotlin.native.nuget.processor.exports.addNugetFunc1HelperExports
 import io.github.xxfast.kotlin.native.nuget.processor.exports.addNugetFunc2HelperExports
 import io.github.xxfast.kotlin.native.nuget.processor.exports.addNugetFunc3HelperExports
-import io.github.xxfast.kotlin.native.nuget.processor.exports.addNugetSuspendFunc0HelperExports
-import io.github.xxfast.kotlin.native.nuget.processor.exports.addNugetSuspendFunc1HelperExports
+import io.github.xxfast.kotlin.native.nuget.processor.exports.addNugetSuspendFuncHelperExports
 import io.github.xxfast.kotlin.native.nuget.processor.exports.addNugetScopeHelperExports
 import io.github.xxfast.kotlin.native.nuget.processor.exports.addNugetScopeDrainExport
 import io.github.xxfast.kotlin.native.nuget.processor.exports.addNugetJobHelperExports
@@ -1121,6 +1120,8 @@ class NugetProcessor(
     if (needsSuspendLambdaSupport) {
       builder.addImport("kotlin.coroutines", "SuspendFunction0")
       builder.addImport("kotlin.coroutines", "SuspendFunction1")
+      builder.addImport("kotlin.coroutines", "SuspendFunction2")
+      builder.addImport("kotlin.coroutines", "SuspendFunction3")
     }
 
     suspendFunctions.forEach { func ->
@@ -1366,8 +1367,7 @@ class NugetProcessor(
     val needsSuspendWrap: Boolean = needsSuspendLambdaSupport &&
         suspendLambdaArities.any { it > 0 } && !needsLambdaSupport
     if (needsSuspendWrap) addNugetWrapHelperExportsOnce()
-    if (0 in suspendLambdaArities) builder.addNugetSuspendFunc0HelperExports()
-    if (1 in suspendLambdaArities) builder.addNugetSuspendFunc1HelperExports()
+    suspendLambdaArities.sorted().forEach { builder.addNugetSuspendFuncHelperExports(it) }
 
     val classesHaveSuspendMethods: Boolean = classes.any { cls ->
       cls.getAllFunctions().any { it.modifiers.contains(Modifier.SUSPEND) }

--- a/nuget-processor/src/main/kotlin/io/github/xxfast/kotlin/native/nuget/processor/exports/GenericClassExports.kt
+++ b/nuget-processor/src/main/kotlin/io/github/xxfast/kotlin/native/nuget/processor/exports/GenericClassExports.kt
@@ -538,76 +538,49 @@ internal fun FileSpec.Builder.addNugetFunc2HelperExports() {
   )
 }
 
-internal fun FileSpec.Builder.addNugetSuspendFunc0HelperExports() {
-  addFunction(
-    FunSpec.builder("export_nuget_suspend_func0_invoke")
-      .addAnnotation(cNameAnnotation("nuget_suspend_func0_invoke"))
-      .addParameter("handle", cOpaquePointer)
-      .addParameter("callbackPtr", cOpaquePointer)
-      .addParameter("userData", cOpaquePointer)
-      .returns(cOpaquePointer)
-      .addCode(buildString {
-        appendLine("val fn = handle.asStableRef<SuspendFunction0<*>>().get()")
-        appendLine("val callback = callbackPtr.reinterpret<CFunction<")
-        appendLine("  (COpaquePointer?, COpaquePointer?, Byte, COpaquePointer) -> Unit>>()")
-        appendLine("val job = CoroutineScope(Dispatchers.Default).launch(start = CoroutineStart.ATOMIC) {")
-        appendLine("  try {")
-        appendLine("    val result = fn.invoke()")
-        appendLine("    if (result == Unit) {")
-        appendLine("      callback.invoke(null, null, 0.toByte(), userData)")
-        appendLine("    } else {")
-        appendLine("      val resultRef = StableRef.create(result as Any).asCPointer()")
-        appendLine("      callback.invoke(resultRef, null, 0.toByte(), userData)")
-        appendLine("    }")
-        appendLine("  } catch (e: CancellationException) {")
-        appendLine("    callback.invoke(null, null, 1.toByte(), userData)")
-        appendLine("    throw e")
-        appendLine("  } catch (e: Throwable) {")
-        appendLine("    val errRef = StableRef.create(buildError(e)).asCPointer()")
-        appendLine("    callback.invoke(null, errRef, 0.toByte(), userData)")
-        appendLine("  }")
-        appendLine("}")
-        append("return StableRef.create(job).asCPointer()")
-      })
-      .build()
-  )
-}
-
-internal fun FileSpec.Builder.addNugetSuspendFunc1HelperExports() {
-  addFunction(
-    FunSpec.builder("export_nuget_suspend_func1_invoke")
-      .addAnnotation(cNameAnnotation("nuget_suspend_func1_invoke"))
-      .addParameter("handle", cOpaquePointer)
-      .addParameter("arg0", cOpaquePointer)
-      .addParameter("callbackPtr", cOpaquePointer)
-      .addParameter("userData", cOpaquePointer)
-      .returns(cOpaquePointer)
-      .addCode(buildString {
-        appendLine("val fn = handle.asStableRef<SuspendFunction1<Any?, Any?>>().get()")
-        appendLine("val param0 = arg0.asStableRef<Any>().get()")
-        appendLine("val callback = callbackPtr.reinterpret<CFunction<")
-        appendLine("  (COpaquePointer?, COpaquePointer?, Byte, COpaquePointer) -> Unit>>()")
-        appendLine("val job = CoroutineScope(Dispatchers.Default).launch(start = CoroutineStart.ATOMIC) {")
-        appendLine("  try {")
-        appendLine("    val result = fn.invoke(param0)")
-        appendLine("    if (result == Unit) {")
-        appendLine("      callback.invoke(null, null, 0.toByte(), userData)")
-        appendLine("    } else {")
-        appendLine("      val resultRef = StableRef.create(result as Any).asCPointer()")
-        appendLine("      callback.invoke(resultRef, null, 0.toByte(), userData)")
-        appendLine("    }")
-        appendLine("  } catch (e: CancellationException) {")
-        appendLine("    callback.invoke(null, null, 1.toByte(), userData)")
-        appendLine("    throw e")
-        appendLine("  } catch (e: Throwable) {")
-        appendLine("    val errRef = StableRef.create(buildError(e)).asCPointer()")
-        appendLine("    callback.invoke(null, errRef, 0.toByte(), userData)")
-        appendLine("  }")
-        appendLine("}")
-        append("return StableRef.create(job).asCPointer()")
-      })
-      .build()
-  )
+/**
+ * ADR-020: the `nuget_suspend_func{N}_invoke` export for one suspend lambda arity. Arities 0-3 are
+ * admitted by `SUSPEND_LAMBDA_TYPES`, and every admitted arity needs its export here: the C# side
+ * emits a `DllImport` for whatever arity it sees, so a missing one fails the forward ABI check (#98).
+ */
+internal fun FileSpec.Builder.addNugetSuspendFuncHelperExports(arity: Int) {
+  val fnType: String = if (arity == 0) "SuspendFunction0<*>" else {
+    "SuspendFunction$arity<${List(arity + 1) { "Any?" }.joinToString(", ")}>"
+  }
+  val params: String = (0 until arity).joinToString(", ") { "param$it" }
+  val builder: FunSpec.Builder = FunSpec.builder("export_nuget_suspend_func${arity}_invoke")
+    .addAnnotation(cNameAnnotation("nuget_suspend_func${arity}_invoke"))
+    .addParameter("handle", cOpaquePointer)
+  repeat(arity) { builder.addParameter("arg$it", cOpaquePointer) }
+  builder
+    .addParameter("callbackPtr", cOpaquePointer)
+    .addParameter("userData", cOpaquePointer)
+    .returns(cOpaquePointer)
+    .addCode(buildString {
+      appendLine("val fn = handle.asStableRef<$fnType>().get()")
+      repeat(arity) { appendLine("val param$it = arg$it.asStableRef<Any>().get()") }
+      appendLine("val callback = callbackPtr.reinterpret<CFunction<")
+      appendLine("  (COpaquePointer?, COpaquePointer?, Byte, COpaquePointer) -> Unit>>()")
+      appendLine("val job = CoroutineScope(Dispatchers.Default).launch(start = CoroutineStart.ATOMIC) {")
+      appendLine("  try {")
+      appendLine("    val result = fn.invoke($params)")
+      appendLine("    if (result == Unit) {")
+      appendLine("      callback.invoke(null, null, 0.toByte(), userData)")
+      appendLine("    } else {")
+      appendLine("      val resultRef = StableRef.create(result as Any).asCPointer()")
+      appendLine("      callback.invoke(resultRef, null, 0.toByte(), userData)")
+      appendLine("    }")
+      appendLine("  } catch (e: CancellationException) {")
+      appendLine("    callback.invoke(null, null, 1.toByte(), userData)")
+      appendLine("    throw e")
+      appendLine("  } catch (e: Throwable) {")
+      appendLine("    val errRef = StableRef.create(buildError(e)).asCPointer()")
+      appendLine("    callback.invoke(null, errRef, 0.toByte(), userData)")
+      appendLine("  }")
+      appendLine("}")
+      append("return StableRef.create(job).asCPointer()")
+    })
+  addFunction(builder.build())
 }
 
 internal fun FileSpec.Builder.addNugetScopeHelperExports() {

--- a/test-library/src/nativeMain/kotlin/io/github/xxfast/kotlin/native/nuget/test/cat/CatFeeder.kt
+++ b/test-library/src/nativeMain/kotlin/io/github/xxfast/kotlin/native/nuget/test/cat/CatFeeder.kt
@@ -21,6 +21,21 @@ class CatFeeder(val catName: String) {
     delay(1.seconds)
   }
 
+  // Issue #98: ADR-020 promised suspend lambda arities 0-3, but only 0 and 1 had a Kotlin export.
+  val onFeedPortion: suspend (String, Int) -> String = { food, grams ->
+    delay(50.milliseconds)
+    "$catName devoured ${grams}g of $food!"
+  }
+
+  val onFeedSchedule: suspend (String, Int, String) -> String = { food, grams, time ->
+    delay(50.milliseconds)
+    "$catName devoured ${grams}g of $food at $time!"
+  }
+
+  val onLogMeal: suspend (String, String) -> Unit = { _, _ ->
+    delay(50.milliseconds)
+  }
+
   val mealAnnouncements: Flow<String> = flow {
     emit("$catName is hungry")
     delay(50.milliseconds)


### PR DESCRIPTION
ADR-020 admitted `SuspendFunction0..3` in `SUSPEND_LAMBDA_TYPES`, but only arity 0 and 1 ever got a Kotlin export or an import in the generated exports file. The C# renderer emits `nuget_suspend_func{N}_invoke` for whatever arity it sees, so a `suspend (A, B) -> R` property failed `packNuget` on a missing export with no `exclude()` escape (#98). Arity 4 was never admitted, so it already degrades to `SKIPPED_UNSUPPORTED_PROPERTY`.

```kotlin
val onFeedPortion: suspend (String, Int) -> String
```

```C#
public KotlinSuspendFunc<string, int, string> OnFeedPortion => new KotlinSuspendFunc<string, int, string>(Native_Get_onFeedPortion(_handle));
string result = await feeder.OnFeedPortion.InvokeAsync("salmon", 40);
```

One parameterized `addNugetSuspendFuncHelperExports(arity)` replaces the two copy-pasted builders.

`scripts/verify.sh` green: 1396 passed, 0 skipped, 0 failed

- [x] Export suspend lambda arities 2 and 3 so the forward ABI check passes (#98)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzjVbjU8eVmebUCSJnSXoC