### PR TITLE
Stop exporting a marked lambda or Flow property (ADR-115)

### DIFF
--- a/IntegrationTests/Issue121Tests.cs
+++ b/IntegrationTests/Issue121Tests.cs
@@ -1,0 +1,108 @@
+using System.Reflection;
+using TestLibrary.Issue121;
+
+namespace IntegrationTests;
+
+/// <summary>
+/// Issue <a href="https://github.com/xxfast/kotlin-native-nuget/issues/121">#121</a>: ADR-115's
+/// opt-in gate lives in the planners, and the lambda and Flow property arms do not go through them.
+/// A marked property was reported <c>SKIPPED_OPT_IN_MARKER</c> and exported anyway, on both sides.
+///
+/// <para>
+/// The Kotlin fixture is <c>test-library/.../issue121/Issue121Sample.kt</c>. Read its KDoc for the
+/// cell table.
+/// </para>
+///
+/// <para>
+/// <b>The criterion that matters is not here.</b> Issue #121's criterion 3 is that the consuming
+/// module compiles with no <c>optIn</c> / <c>-opt-in=</c> flag in any build script. That is proven
+/// by <c>packNuget</c> compiling the fixture at all, not by anything xunit can assert: before the
+/// fix the generated <c>CNameExports.kt</c> read the marked properties without opting in and the
+/// module did not build. What is left for here is the C# half, criterion 2 and criterion 4.
+/// </para>
+///
+/// <para>
+/// <b>The absence trap.</b> Absence assertions cannot catch a gate that fires too wide, and a
+/// lambda property is easy to drop for a dozen unrelated reasons. So every marked property in the
+/// fixture has an unmarked sibling of exactly the same type in the same class, and those controls
+/// run first.
+/// </para>
+///
+/// <para>
+/// Oreo naps through the refresh. Mylo retries anyway.
+/// </para>
+/// </summary>
+public class Issue121Tests
+{
+    private const BindingFlags PublicInstance = BindingFlags.Public | BindingFlags.Instance;
+
+    private static bool HasMember(Type type, string name) =>
+        type.GetProperty(name, PublicInstance) is not null ||
+        type.GetMethod(name, PublicInstance) is not null;
+
+    // -----------------------------------------------------------------------------------------
+    // Controls first. A gate that swept up every lambda property would pass every absence test
+    // below, so these have to fail loudly before any of them run.
+    // -----------------------------------------------------------------------------------------
+
+    [Fact]
+    public void C1_UnmarkedSiblings_OfTheMarkedProperties_AreStillExported()
+    {
+        // Same class, same three types (plain lambda, suspend lambda, Flow) as the marked trio.
+        Assert.True(HasMember(typeof(Feed), "OnVisible"), "unmarked `() -> Unit` must survive");
+        Assert.True(HasMember(typeof(Feed), "OnSettle"), "unmarked `suspend () -> Unit` must survive");
+        Assert.True(HasMember(typeof(Feed), "OnPulse"), "unmarked `Flow<Int>` must survive");
+        Assert.True(HasMember(typeof(Panel.Live), "OnOpen"), "unmarked sealed-arm lambda must survive");
+    }
+
+    [Fact]
+    public void C2_TheUnmarkedDelegates_AreExportedAndWork()
+    {
+        // Criterion 4: these are the intended surface, and they are what makes gating the marked
+        // properties cost the consumer nothing.
+        using Feed feed = new Feed(3);
+
+        Assert.Equal(0, feed.Retries);
+        feed.Retry();
+        Assert.Equal(1, feed.Retries);
+    }
+
+    [Fact]
+    public async Task C3_TheUnmarkedSuspendDelegate_IsExportedAndWorks()
+    {
+        using Feed feed = new Feed(3);
+
+        Assert.Equal(0, feed.Refreshes);
+        await feed.RefreshAsync();
+        Assert.Equal(1, feed.Refreshes);
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Criterion 2: no C# member for a marked property, on either route.
+    // -----------------------------------------------------------------------------------------
+
+    [Fact]
+    public void Cell1_MarkedPlainLambdaProperty_IsNotExported()
+    {
+        Assert.False(HasMember(typeof(Feed), "OnRetry"), "the issue's literal reported shape");
+    }
+
+    [Fact]
+    public void Cell2_MarkedSuspendLambdaProperty_IsNotExported()
+    {
+        Assert.False(HasMember(typeof(Feed), "OnRefresh"), "the suspend copy of the same arm");
+    }
+
+    [Fact]
+    public void Cell3_MarkedFlowProperty_IsNotExported()
+    {
+        // Not named in the issue. The Flow arm shares the fall-through, so it leaked too.
+        Assert.False(HasMember(typeof(Feed), "OnTicks"), "the Flow arm of the same fall-through");
+    }
+
+    [Fact]
+    public void Cell4_MarkedLambdaProperty_OnASealedArm_IsNotExported()
+    {
+        Assert.False(HasMember(typeof(Panel.Live), "OnClose"), "the SealedClassExports copy");
+    }
+}

--- a/docs/adr/115-opt-in-marker-declarations.md
+++ b/docs/adr/115-opt-in-marker-declarations.md
@@ -385,6 +385,28 @@ Two different places, because a marked class and a marked member fail differentl
   and render both reasons through one `ForwardDiagnosticKind.SKIPPED_OPT_IN_MARKER`, exactly as
   `UNEXPORTED_DEPENDENCY_TYPE` / `EXCLUDED_DEPENDENCY_TYPE` share one kind today.
 
+#### Amendment (issue #121): the legacy routes need the gate spelled out
+
+The split above says the member skip is "a per-callable skip in `ForwardCallablePlanner`", which is
+true and was not sufficient. It locates the gate in the planner, and the lambda, suspend-lambda and
+`Flow` property arms do not run through the planner: they run *after* it declines, on both sides
+(`ClassExports`, `SealedClassExports`, and the two matching arms in `CirClassTranslator`).
+
+Those arms read a null plan as "the planner has no shape for this type", which is what they exist
+for. A refusal is also a null plan. So a marked lambda or `Flow` property was reported
+`SKIPPED_OPT_IN_MARKER` by the planner and then emitted anyway, on both sides, and the generated
+`CNameExports.kt` read a marked declaration without opting in. Nineteen members leaked in one real
+project before this was caught.
+
+The gate is therefore not "the planner refuses it" but **"no route emits a refused declaration"**.
+Every arm that runs after a null plan asks `isOptInRefused()` before emitting. The property still
+reaches the planner, so the diagnostic is unchanged; only the emitters are gated.
+
+This generalises beyond opt-in: a declaration named in any `SKIPPED_*` diagnostic must be absent
+from both generated artifacts, and that pairing is mechanically checkable over a Tier 1 result
+(`kspWarnings` against `generated` and `generatedCSharp`). `Tier1OptInLambdaRouteTest` asserts it
+over its own fixture; making it a global invariant is a broader change than this fix.
+
 ### Consumer-side API
 
 The C# consumer sees the *absence* of output. For the issue's reproducer, `State` is still exported;

--- a/nuget-processor/src/main/kotlin/io/github/xxfast/kotlin/native/nuget/processor/cir/CirClassTranslator.kt
+++ b/nuget-processor/src/main/kotlin/io/github/xxfast/kotlin/native/nuget/processor/cir/CirClassTranslator.kt
@@ -17,6 +17,7 @@ import io.github.xxfast.kotlin.native.nuget.processor.csharpParameterName
 import io.github.xxfast.kotlin.native.nuget.processor.exports.findInterfaceBridgePairs
 import io.github.xxfast.kotlin.native.nuget.processor.exports.findStoredCallbackPairs
 import io.github.xxfast.kotlin.native.nuget.processor.forward.ForwardBridgeTypeClassifier
+import io.github.xxfast.kotlin.native.nuget.processor.forward.isOptInRefused
 import io.github.xxfast.kotlin.native.nuget.processor.forward.ForwardCallableCatalogEntry
 import io.github.xxfast.kotlin.native.nuget.processor.forward.ForwardCallablePlan
 import io.github.xxfast.kotlin.native.nuget.processor.forward.ForwardCallablePlanCatalog
@@ -287,6 +288,9 @@ internal fun translateClass(
           isVirtual = prop.modifiers.isOpenInterfaceImplementation(superClass),
         )
       }
+      // Issue #121: the planner declined, but a decline is not always an invitation. A marked
+      // declaration must reach neither artifact, so the legacy arms below never run for one.
+      if (prop.isOptInRefused()) return@mapNotNull null
       // Named specialized-protocol property adapters only (lambda / suspend-lambda / Flow).
       // Ordinary property types without a plan are skipped — no mapReturnType IntPtr fallthrough.
       val propTypeResolved: KSType = prop.type.resolve().expandAliases()
@@ -1185,6 +1189,10 @@ internal fun translateSealedClass(
             tracker.trackProperty(planned)
             return@mapNotNull ForwardCirPropertyProjection.classProperty(planned)
           }
+
+          // Issue #121: same gate as the ordinary-class arm above. The planner declined, and a
+          // marked declaration must reach neither artifact.
+          if (prop.isOptInRefused()) return@mapNotNull null
 
           // Residual legacy route: a lambda-typed property, whose Kotlin half is still
           // hand-spelled in `SealedClassExports` too. It swallows the error slot (`out _`) until

--- a/nuget-processor/src/main/kotlin/io/github/xxfast/kotlin/native/nuget/processor/exports/ClassExports.kt
+++ b/nuget-processor/src/main/kotlin/io/github/xxfast/kotlin/native/nuget/processor/exports/ClassExports.kt
@@ -32,6 +32,7 @@ import io.github.xxfast.kotlin.native.nuget.processor.forward.ForwardPropertyPla
 import io.github.xxfast.kotlin.native.nuget.processor.forward.addForwardKotlinPlanExport
 import io.github.xxfast.kotlin.native.nuget.processor.forward.planFor
 import io.github.xxfast.kotlin.native.nuget.processor.forward.addForwardPropertyPlanExports
+import io.github.xxfast.kotlin.native.nuget.processor.forward.isOptInRefused
 import io.github.xxfast.kotlin.native.nuget.processor.toCName
 
 /**
@@ -90,6 +91,9 @@ internal fun FileSpec.Builder.addClassExports(
       addForwardPropertyPlanExports(planned)
       return@forEach
     }
+    // Issue #121: the planner declined, but a decline is not always an invitation. A marked
+    // declaration must reach neither artifact, so the legacy arms below never run for one.
+    if (prop.isOptInRefused()) return@forEach
     // Named specialized-protocol property adapters (lambda / suspend-lambda / Flow).
     val propTypeResolved: KSType = prop.type.resolve().expandAliases()
     val propType: String = propTypeResolved.declaration.qualifiedName?.asString() ?: "Any"

--- a/nuget-processor/src/main/kotlin/io/github/xxfast/kotlin/native/nuget/processor/exports/SealedClassExports.kt
+++ b/nuget-processor/src/main/kotlin/io/github/xxfast/kotlin/native/nuget/processor/exports/SealedClassExports.kt
@@ -14,6 +14,7 @@ import io.github.xxfast.kotlin.native.nuget.processor.forward.ForwardCallablePla
 import io.github.xxfast.kotlin.native.nuget.processor.forward.ForwardPropertyPlan
 import io.github.xxfast.kotlin.native.nuget.processor.forward.addForwardKotlinPlanExport
 import io.github.xxfast.kotlin.native.nuget.processor.forward.addForwardPropertyPlanExports
+import io.github.xxfast.kotlin.native.nuget.processor.forward.isOptInRefused
 import io.github.xxfast.kotlin.native.nuget.processor.forward.handleBody
 import io.github.xxfast.kotlin.native.nuget.processor.forward.nullableHandleBody
 
@@ -79,6 +80,10 @@ internal fun FileSpec.Builder.addSealedClassExports(
         addForwardPropertyPlanExports(planned)
         continue
       }
+
+      // Issue #121: the planner declined, but a decline is not always an invitation. A marked
+      // declaration must reach neither artifact, so the legacy arm below never runs for one.
+      if (prop.isOptInRefused()) continue
 
       // Residual legacy route: a lambda-typed property, which has no plan shape yet (the C# half
       // still spells its own `KotlinFunc<...>` arm in `translateSealedClass`). Everything else the

--- a/nuget-processor/src/main/kotlin/io/github/xxfast/kotlin/native/nuget/processor/forward/ForwardOptInMarkers.kt
+++ b/nuget-processor/src/main/kotlin/io/github/xxfast/kotlin/native/nuget/processor/forward/ForwardOptInMarkers.kt
@@ -69,6 +69,25 @@ internal fun KSAnnotated.optInMarker(): String? {
 }
 
 /**
+ * Issue #121: whether a legacy (non-plan) route must refuse to emit this property.
+ *
+ * `ForwardCallablePlanCatalog.propertyFor` answers null for two opposite reasons: the planner has
+ * no shape for the type, which is exactly what the legacy lambda and Flow arms exist to handle,
+ * and the planner *refused* the declaration, which nothing may emit. A legacy arm that reads only
+ * "no plan" takes the second case as an invitation, so an opt-in marked lambda property was
+ * reported `SKIPPED_OPT_IN_MARKER` and exported anyway, on both sides of the bridge.
+ *
+ * Every plan-driven route already gets this from the planner. Only the arms that run *after* a
+ * null plan need to ask, which is why this is a predicate rather than another filter on the
+ * property list: the property must still reach the planner to be diagnosed.
+ *
+ * The requirement is absence, not compilability. C# has no equivalent of a Kotlin opt-in marker,
+ * so a member that reaches `Interop.cs` is unconditionally public API in the shipped package with
+ * no way to re-hide it downstream.
+ */
+internal fun KSPropertyDeclaration.isOptInRefused(): Boolean = optInMarker() != null
+
+/**
  * ADR-115: the marker on a constructor parameter, read from the parameter itself *and* from the
  * property a `val`/`var` parameter declares.
  *

--- a/nuget-processor/src/test/kotlin/io/github/xxfast/kotlin/native/nuget/processor/tier1/Tier1OptInLambdaRouteTest.kt
+++ b/nuget-processor/src/test/kotlin/io/github/xxfast/kotlin/native/nuget/processor/tier1/Tier1OptInLambdaRouteTest.kt
@@ -1,0 +1,164 @@
+package io.github.xxfast.kotlin.native.nuget.processor.tier1
+
+import io.github.xxfast.kotlin.native.nuget.processor.forward.ForwardDiagnosticKind
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Issue #121. ADR-115's opt-in gate lives in the planners, and the lambda-property route does not
+ * go through them. `ClassExports.kt:88` and its sealed twin ask the catalog for a plan and, when
+ * there is none, fall through to a legacy arm that emits unconditionally:
+ *
+ * ```kotlin
+ * val planned: ForwardPropertyPlan? = callableCatalog.propertyFor("$qualifiedName.$propName")
+ * if (planned != null) { addForwardPropertyPlanExports(planned); return@forEach }
+ * // legacy arm, emits a lambda or Flow getter with no gate of its own
+ * ```
+ *
+ * `planned == null` conflates two opposite answers: "the planner has no shape for this type", which
+ * is what the legacy arm exists for, and "the planner refused this declaration", which nothing may
+ * emit. So a marked lambda property is reported `SKIPPED_OPT_IN_MARKER` and then exported anyway,
+ * on both sides.
+ *
+ * That also explains why the gate looks correct everywhere else: for a marked *non-lambda* property
+ * the fall-through reaches no arm and emits nothing, so it is excluded by accident rather than by
+ * the gate.
+ *
+ * The requirement is absence, not compilability (issue #121, "Please do not fix it these two
+ * ways"). C# has no equivalent of a Kotlin opt-in marker, so a member that reaches `Interop.cs` is
+ * unconditionally public API in the shipped package with no way to re-hide it. Opting the generated
+ * Kotlin in would make the build green and still ship the member.
+ *
+ * [Tier1OptInMarkerSkipTest] owns the detection side; this file owns the emitters.
+ *
+ * Oreo refuses to be public API. Mylo has no opinion.
+ */
+class Tier1OptInLambdaRouteTest {
+
+  private val source: String = """
+    package tier1.optin.lambda
+
+    import kotlinx.coroutines.flow.Flow
+    import kotlinx.coroutines.flow.flowOf
+
+    @RequiresOptIn(level = RequiresOptIn.Level.ERROR, message = "internal")
+    @Retention(AnnotationRetention.BINARY)
+    @Target(
+      AnnotationTarget.CLASS,
+      AnnotationTarget.FUNCTION,
+      AnnotationTarget.PROPERTY,
+      AnnotationTarget.CONSTRUCTOR,
+    )
+    annotation class InternalMarker
+
+    class Feed(val items: Int) {
+      @property:InternalMarker val onRefresh: suspend () -> Unit = {}
+      @property:InternalMarker val onRetry: () -> Unit = {}
+      @property:InternalMarker val onTicks: Flow<Int> = flowOf(1)
+
+      val onVisible: () -> Unit = {}
+
+      suspend fun refresh() = onRefresh()
+      fun retry() = onRetry()
+    }
+
+    sealed class Panel {
+      data class Live(val label: String) : Panel() {
+        @property:InternalMarker val onClose: () -> Unit = {}
+        val onOpen: () -> Unit = {}
+      }
+    }
+  """.trimIndent()
+
+  private fun run(): Tier1Result = Tier1Harness.run(
+    source,
+    libraries = listOf(Tier1Classpath.kotlinxCoroutinesCore),
+  )
+
+  /** Criterion 1: no `@CName` thunk for a marked property in the generated Kotlin. */
+  @Test
+  fun `a marked lambda property has no CName getter in the generated Kotlin`() {
+    val result = run()
+    val kotlin: String = result.generated
+
+    listOf("feed_get_onRefresh", "feed_get_onRetry", "panel_live_get_onClose").forEach { export ->
+      assertTrue(
+        export !in kotlin,
+        "a marked property must not reach the generated Kotlin, found `$export`",
+      )
+    }
+  }
+
+  /** The Flow arm of the same fall-through, which the issue does not name but shares the route. */
+  @Test
+  fun `a marked Flow property has no CName export in the generated Kotlin`() {
+    val result = run()
+
+    assertTrue(
+      "onTicks" !in result.generated,
+      "a marked Flow property goes down the same legacy fall-through and must be gated too",
+    )
+  }
+
+  /** Criterion 2: no C# member for a marked property in the generated bindings. */
+  @Test
+  fun `a marked lambda property has no C# member`() {
+    val result = run()
+    val cs: String = result.generatedCSharp
+
+    listOf("OnRefresh", "OnRetry", "OnTicks", "OnClose").forEach { member ->
+      assertTrue(
+        member !in cs,
+        "a marked property must not reach Interop.cs, found `$member`. C# has no opt-in " +
+            "marker, so anything emitted here is unconditionally public in the package",
+      )
+    }
+  }
+
+  /**
+   * Criterion 4, the control. The unmarked functions that delegate to the marked properties are
+   * the intended surface and must keep binding, so the gate cannot simply take the class with it.
+   */
+  @Test
+  fun `the unmarked delegating members still bind`() {
+    val result = run()
+    val cs: String = result.generatedCSharp
+
+    assertTrue("RefreshAsync" in cs, "the unmarked suspend delegate must survive; got:\n$cs")
+    assertTrue("Retry" in cs, "the unmarked delegate must survive")
+    assertTrue("OnVisible" in cs, "an unmarked lambda property on the same class must survive")
+    assertTrue("OnOpen" in cs, "an unmarked lambda property on the sealed arm must survive")
+  }
+
+  /**
+   * The invariant issue #121 asks for, and the one that would have caught this before release: a
+   * declaration named in any `SKIPPED_*` diagnostic must be absent from both artifacts. Asserted
+   * here over this fixture rather than globally, which is a broader change than one bug fix.
+   */
+  @Test
+  fun `nothing named in a SKIPPED diagnostic appears in either artifact`() {
+    val result = run()
+
+    val skipped: List<String> = result.kspWarnings
+      .filter { it.contains(ForwardDiagnosticKind.SKIPPED_OPT_IN_MARKER.name) }
+      .mapNotNull { warning ->
+        Regex("""tier1\.optin\.lambda\.[\w.]+""").find(warning)?.value
+      }
+      .map { it.substringAfterLast('.') }
+      .distinct()
+
+    assertTrue(skipped.isNotEmpty(), "expected the marked properties to be reported at all")
+
+    skipped.forEach { member ->
+      val pascal: String = member.replaceFirstChar { it.uppercase() }
+      assertTrue(
+        member !in result.generated,
+        "`$member` is reported skipped yet present in the generated Kotlin",
+      )
+      assertTrue(
+        pascal !in result.generatedCSharp,
+        "`$member` is reported skipped yet present as `$pascal` in the generated C#",
+      )
+    }
+  }
+}

--- a/test-library/src/nativeMain/kotlin/io/github/xxfast/kotlin/native/nuget/test/issue121/Issue121Sample.kt
+++ b/test-library/src/nativeMain/kotlin/io/github/xxfast/kotlin/native/nuget/test/issue121/Issue121Sample.kt
@@ -1,0 +1,94 @@
+package io.github.xxfast.kotlin.native.nuget.test.issue121
+
+import io.github.xxfast.kotlin.native.nuget.test.issue113.InternalApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+/**
+ * Issue #121: ADR-115's opt-in gate lives in the planners, and the lambda and Flow property arms do
+ * not go through them. `ClassExports.kt` and `SealedClassExports.kt` ask the catalog for a plan and
+ * fall through to a legacy arm when there is none, but `no plan` answers two opposite questions:
+ * "no shape for this type", which the legacy arm exists for, and "the planner refused this
+ * declaration", which nothing may emit. So a marked lambda property was reported
+ * `SKIPPED_OPT_IN_MARKER` and exported anyway, on both sides.
+ *
+ * **This fixture is the criterion-3 test.** It is compiled by `packNuget` with no `optIn` or
+ * `-opt-in=` flag anywhere in any build script. Before the fix the generated `CNameExports.kt` read
+ * these marked properties without opting in and the module did not compile, so the fixture existing
+ * and the build being green is itself the assertion. `IntegrationTests/Issue121Tests.cs` then owns
+ * the C# absence half.
+ *
+ * **The absence trap**, inherited from [io.github.xxfast.kotlin.native.nuget.test.issue113]: this
+ * pipeline drops members for many unrelated reasons, and a lambda property is easier to drop than
+ * the `String` that fixture leans on. So every marked property here has an **unmarked sibling of
+ * exactly the same type** in the same class. Those controls are the only thing that can catch a
+ * gate that fires too wide, which absence assertions structurally cannot.
+ *
+ * | Cell | Member | What it pins |
+ * |---|---|---|
+ * | 1 | [Feed.onRetry] | the issue's literal shape: `@property:` marker on a plain `() -> Unit` |
+ * | 2 | [Feed.onRefresh] | the suspend arm, a separate copy of the same fall-through |
+ * | 3 | [Feed.onTicks] | the `Flow` arm, which shares the fall-through and the issue does not name |
+ * | 4 | [Panel.Live.onClose] | the sealed-subclass copy, in `SealedClassExports` |
+ * | C1 | [Feed.onVisible] | control for cell 1, unmarked, same type |
+ * | C2 | [Feed.onSettle] | control for cell 2, unmarked, same type |
+ * | C3 | [Feed.onPulse] | control for cell 3, unmarked, same type |
+ * | C4 | [Panel.Live.onOpen] | control for cell 4, unmarked, same type |
+ * | C5 | [Feed.retry] / [Feed.refresh] | criterion 4: the unmarked delegates are the intended surface and must still work |
+ *
+ * Oreo naps through the refresh. Mylo retries anyway.
+ */
+class Feed(val items: Int) {
+
+  /** Cell 1: the issue's literal reported shape. */
+  @property:InternalApi
+  val onRetry: () -> Unit = { retries++ }
+
+  /** Cell 2: the suspend twin, through the other copy of the arm. */
+  @property:InternalApi
+  val onRefresh: suspend () -> Unit = { refreshes++ }
+
+  /** Cell 3: the Flow arm of the same fall-through. */
+  @property:InternalApi
+  val onTicks: Flow<Int> = flowOf(1, 2, 3)
+
+  /** C1, C2, C3: unmarked siblings of the same three types, which must keep binding. */
+  val onVisible: () -> Unit = { }
+  val onSettle: suspend () -> Unit = { }
+  val onPulse: Flow<Int> = flowOf(7, 8, 9)
+
+  var retries: Int = 0
+
+  var refreshes: Int = 0
+
+  /**
+   * C5: criterion 4. The unmarked delegates are the intended surface, and cost the consumer
+   * nothing once the marked properties are gated.
+   *
+   * `@OptIn` is required here and is not a workaround: reading an opt-in-required property needs
+   * opting in even inside the declaring class, and this is the library author doing so knowingly
+   * at one point of use. The thing issue #121 forbids is opting in on the *generated* file, which
+   * would ship the marked member to C# anyway. Same shape as `Cattery.consumesMarked` in
+   * [io.github.xxfast.kotlin.native.nuget.test.issue113]: a marker consumer stays exported, a
+   * marker member does not.
+   */
+  @OptIn(InternalApi::class)
+  fun retry() = onRetry()
+
+  @OptIn(InternalApi::class)
+  suspend fun refresh() = onRefresh()
+}
+
+/** Cell 4 and C4: the sealed-subclass copy of the same arm, in `SealedClassExports`. */
+sealed class Panel {
+
+  data class Live(val label: String) : Panel() {
+
+    @property:InternalApi
+    val onClose: () -> Unit = { }
+
+    val onOpen: () -> Unit = { }
+  }
+
+  data class Off(val reason: String) : Panel()
+}


### PR DESCRIPTION
Fixes #121

ADR-115's gate lives in the planners, and the lambda, suspend-lambda and `Flow` property arms do not run through them. They run *after* the planner declines, and a decline answers two opposite questions: "no shape for this type", which is what those arms exist for, and "the planner refused this declaration", which nothing may emit. Reading every decline as the first shipped the member anyway.

```kotlin
@property:InternalApi val onRetry: () -> Unit = { retries++ }
fun retry() = onRetry()
```

```csharp
// before: reported SKIPPED_OPT_IN_MARKER, emitted regardless
public KotlinAction OnRetry => new KotlinAction(Native_Get_onRetry(_handle));

// after: absent. `Retry()` is the intended surface and is untouched
public void Retry()
```

The `Flow` arm was leaking too, which the issue does not name: it shares the same fall-through, and `Feed.onTicks` failed exactly like the lambdas. Criterion 3 is proven by `packNuget` compiling the fixture at all rather than by an assertion, since before this the generated `CNameExports.kt` read a marked declaration without opting in; there is no `optIn` flag in any build script. The `@OptIn` on the fixture's own `retry()` is required Kotlin and is the thing the issue permits, not the thing it forbids: opting in on the *generated* file is what would ship the member.

`scripts/verify.sh` green: 1541 passed, 0 skipped, 0 failed.

- [x] Stop exporting a marked lambda or Flow property (ADR-115)
