### PR TITLE
Prepare for release 0.6.0

### DIFF
--- a/docs/topics/prerequisites.md
+++ b/docs/topics/prerequisites.md
@@ -28,7 +28,7 @@ additional tooling.
 
 | kotlin-native-nuget | Kotlin   | KSP      | Gradle | JDK | .NET   |
 |----------------------|----------|----------|--------|-----|--------|
-| `0.2.0` – `0.5.0`    | `2.4.10` | `2.3.10` | `9.1`  | 17+ | `8.0`+ |
+| `0.2.0` – `0.6.0`    | `2.4.10` | `2.3.10` | `9.1`  | 17+ | `8.0`+ |
 | `0.1.0`              | `2.4.0`  | `2.3.9`  | `9.1`  | 17+ | `8.0`+ |
 
 KSP is pinned to its Kotlin version, so bumping Kotlin without bumping the plugin is not

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # Single source of truth for the version. The `nuget-plugin` included build does not
 # inherit these across the composite boundary, so it reads this file explicitly.
 group=io.github.xxfast
-version=0.5.0
+version=0.6.0
 
 #Kotlin
 kotlin.code.style=official


### PR DESCRIPTION
- Bind suspend collection returns as `Task<IReadOnlyList<T>>` (ADR-119) (#124)
- Stop exporting a marked lambda or Flow property (ADR-115) (#123)
- Update sample hash to dca5a40
- Number suspend overloads and bind suspend methods on sealed arms (ADR-118) (#120)
- Name the owning declarations in a forward ABI entry-point collision (ADR-117) (#119)
- Export a sealed subclass's declared member functions (ADR-116) (#118)
- Bind a Unit-returning lambda as KotlinAction (#117)
- Skip opt-in-marked declarations from the C# surface (ADR-115) (#116)
- Allow Fixes #NNN in a PR body, and drop the stale no-tracker premise
- Document the six-issue batch
- Style pass over the six-issue batch
- Project a generated interface from the forward plan (ADR-113)
- Marshal a collection parameter on the flow and suspend routes (ADR-114)
- Qualify a lambda's type arguments, or skip the member naming why (ADR-066)
- Let the sealed route own an object arm on both object routes (ADR-009)
- Carry nullability through a suspend return on both sides of the bridge (ADR-019)
- Bind a data object sealed subclass's properties in C# (ADR-111)
- Number Flow and StateFlow method overloads on every entry point (ADR-090) (#105)
- Export suspend lambda arities 2 and 3 so the forward ABI check passes (ADR-020) (#104)
- Skip a reference-underlying value class secondary constructor instead of rendering a broken one (ADR-035) (#101)
- Bind a value class over a sealed type at property and callable positions (ADR-105) (#100)
- Bind Equals, GetHashCode and ToString on a data object sealed subclass (ADR-009) (#99)
- Map an eligible sealed interface through the sealed-class route (ADR-112) (#96)
- Bridge a sealed type at parameter positions and the mutable sealed collection setter (ADR-105) (#95)
- Name the skip for a sealed type at a parameter position (ADR-064) (#94)
- Plan a sealed return on every callable route (ADR-009) (#93)
- Plan sealed-subclass properties through the property plan (ADR-111) (#92)
- Name the skip for a nested class or object, module-local and from a dependency (ADR-064) (#91)
- Escape C# member names at render time only (ADR-062) (#90)
- Rename a user parameter that spells a generator-owned ABI slot (ADR-062) (#89)
- Escape keyword and error-named parameters on every legacy C# route (ADR-024) (#88)
- Render top-level functions PascalCase in C# (ADR-110) (#87)
- Warn once when every public constructor of a class is skipped (ADR-064) (#86)
- Elide a static class left with no members and the namespace left empty by it (ADR-064) (#85)
- Keep an override of a read-only base property get-only in C# (ADR-075) (#84)
- Derive the diagnostic verb from the kind prefix and drop the dead disposable branch (#83)
- Name the true refusal reason in the dependency-type skip hint (ADR-109) (#82)
- Name the skip for a public annotation class (ADR-064) (#81)
- Synthesize omitting overloads for overloaded top-level expect functions (ADR-096) (#80)
- Collect a sibling sealed subclass once, on the sealed route (ADR-009) (#79)
- Name the skip for a nested interface at a member position (ADR-040) (#78)