### PR TITLE
Verify the runtime's `nuget_*` exports on the Windows leg, locally and in CI (ADR-127)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,15 @@ jobs:
       - name: Build NuGet package
         run: ./gradlew :test-library:packNuget
 
+      # ADR-127 seam 3 runs on both matrix legs: the runtime's `nuget_*` exports were only ever
+      # spiked on macosArm64, so checking the linked library here turns a missing Windows export
+      # into a build failure instead of an `EntryPointNotFoundException` in the dotnet tests below.
+      # Under Git Bash on the Windows runner `$HOME` is the user profile, so the script's
+      # `~/.konan/dependencies/msys2-mingw-w64-x86_64-*/bin/nm.exe` glob resolves there too.
+      - name: Runtime exports present in the linked library
+        run: scripts/verify-runtime-exports.sh
+        shell: bash
+
       - name: Check generated bindings compile as a consumer (net8.0, warnings as errors)
         run: dotnet build GeneratedBindingsCheck
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -194,7 +194,6 @@ Bullets 1 to 3 shipped in [ADR-127](docs/adr/127-nuget-runtime-library.md): the 
 - [ ] A runtime `launchForCSharp(callback, userData) { body }` helper collapsing the ~20-line `*_async`, Flow collect and `*_bridge_create` launch shape (14 copies in the fixture) to a few lines. A generator change on top of the runtime, second step.
 - [ ] The C# twin: `Interop.cs`'s roughly 1.8k fixed lines as a runtime NuGet package. Blocked on a per-library `DllImportResolver` (every `DllImport` names its library at compile time and one .NET process can host several Kotlin libraries); decide together with the opt-in compiled-assembly packaging mode under Future Improvements.
 - [ ] A `nuget_runtime_version(): String` export so `NUGET_INTEROP_TRACE=1` can print which runtime a process loaded. Deferred by [ADR-127](docs/adr/127-nuget-runtime-library.md) Consequences; an option for bullet 5 above, not shipped with the module itself.
-- [ ] `mingwX64` export of the runtime's `nuget_*` symbols is verified only by CI's Windows leg (`llvm-nm`/`dumpbin` in `scripts/verify-runtime-exports.sh`), never locally; the [ADR-127](docs/adr/127-nuget-runtime-library.md) spike ran on `macosArm64` only.
 - [ ] The reverse bridge's own `NugetError` (`build/nuget-interop`, structurally identical to the runtime's) can now fold onto the runtime's public one instead of staying a second copy. Named but not done by [ADR-127](docs/adr/127-nuget-runtime-library.md), which moved the forward side only.
 
 ## Post-migration hardening

--- a/docs/topics/registration-diagnostics.md
+++ b/docs/topics/registration-diagnostics.md
@@ -299,8 +299,9 @@ go red, not just pass by construction.
   [ADR-127](https://github.com/xxfast/kotlin-native-nuget/blob/main/docs/adr/127-nuget-runtime-library.md)
   a missing `nuget_*` entry point specifically (as opposed to a per-declaration one) means the
   `nuget-runtime` library was not `export()`ed into the shared library; `scripts/verify-runtime-exports.sh`
-  checks for exactly this by running `nm -gU` (`llvm-nm`/`dumpbin` on Windows) against the linked
-  binary for all 66 names.
+  checks for exactly this against the linked binary for all 66 names, auto-selecting the platform's
+  linked library (`.dylib`, `.dll`, `.so`) and reading it with BSD `nm -gU` on macOS or, on Windows
+  and Linux, the GNU `nm` that Kotlin/Native's own msys2 toolchain dependency ships.
 - Tracing the native library's own load path (which `runtimes/{rid}/native/` payload the CLR actually
   resolved) is a separate, unaddressed problem; this feature covers registration, not load resolution.
 

--- a/scripts/verify-runtime-exports.sh
+++ b/scripts/verify-runtime-exports.sh
@@ -14,10 +14,39 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
 RUNTIME_SOURCE="nuget-runtime/src/nativeMain/kotlin/io/github/xxfast/kotlin/native/nuget/runtime/NugetRuntime.kt"
-LIBRARY="${1:-test-library/build/bin/macosArm64/releaseShared/libtest.dylib}"
+
+# Candidates in host order: whichever target this machine actually linked is the one to check.
+# The ADR-127 spike only ever ran on macosArm64; mingwX64 is the leg that can regress silently,
+# so the Windows binary is a first-class candidate here rather than something you pass by hand.
+CANDIDATES=(
+  "test-library/build/bin/macosArm64/releaseShared/libtest.dylib"
+  "test-library/build/bin/mingwX64/releaseShared/test.dll"
+  "test-library/build/bin/linuxX64/releaseShared/libtest.so"
+)
 
 if [ ! -f "$RUNTIME_SOURCE" ]; then
   echo "runtime source not found: $RUNTIME_SOURCE" >&2
+  exit 1
+fi
+
+LIBRARY="${1:-}"
+if [ -z "$LIBRARY" ]; then
+  for candidate in "${CANDIDATES[@]}"; do
+    if [ -f "$candidate" ]; then
+      LIBRARY="$candidate"
+      break
+    fi
+  done
+fi
+
+if [ -z "$LIBRARY" ]; then
+  {
+    echo "no linked shared library found (pack the sample first: ./gradlew :test-library:packNuget)"
+    echo "looked for:"
+    for candidate in "${CANDIDATES[@]}"; do
+      echo "  $candidate"
+    done
+  } >&2
   exit 1
 fi
 
@@ -26,17 +55,63 @@ if [ ! -f "$LIBRARY" ]; then
   exit 1
 fi
 
+# GNU `nm` for the PE/ELF branches. Kotlin/Native ships one in its own msys2 toolchain dependency,
+# which is present on every machine that has linked mingwX64, so the Windows leg needs no extra
+# install and no `dumpbin` from a Visual Studio prompt.
+find_gnu_nm() {
+  local konan="${KONAN_DATA_DIR:-$HOME/.konan}"
+  local candidates=()
+  shopt -s nullglob
+  candidates=("$konan"/dependencies/msys2-mingw-w64-x86_64-*/bin/nm.exe)
+  shopt -u nullglob
+  if [ ${#candidates[@]} -gt 0 ]; then
+    local newest=""
+    for candidate in "${candidates[@]}"; do
+      if [ -z "$newest" ] || [ "$candidate" -nt "$newest" ]; then
+        newest="$candidate"
+      fi
+    done
+    echo "$newest"
+    return 0
+  fi
+  if command -v llvm-nm >/dev/null 2>&1; then
+    echo "llvm-nm"
+    return 0
+  fi
+  if command -v nm >/dev/null 2>&1; then
+    echo "nm"
+    return 0
+  fi
+  {
+    echo "no symbol lister found for $LIBRARY; tried, in order:"
+    echo "  \$KONAN_DATA_DIR/dependencies/msys2-mingw-w64-x86_64-*/bin/nm.exe (looked under $konan)"
+    echo "  llvm-nm on PATH"
+    echo "  nm on PATH"
+  } >&2
+  return 1
+}
+
 EXPECTED="$(grep -o '@CName("nuget_[a-z0-9_]*")' "$RUNTIME_SOURCE" | sed 's/@CName("//; s/")//' | sort -u)"
 EXPECTED_COUNT="$(printf '%s\n' "$EXPECTED" | wc -l | tr -d ' ')"
 
 case "$LIBRARY" in
-  *.dll) ACTUAL="$(llvm-nm --defined-only --extern-only "$LIBRARY" | awk '{print $NF}' | sort -u)" ;;
+  # PE (x86_64) and ELF exports carry no leading underscore, so the names come out verbatim.
+  # The lookup is its own statement: folded into the command position, a failed lookup would run
+  # the empty string and bury the message above under a `: command not found`.
+  *.dll | *.so)
+    NM_TOOL="$(find_gnu_nm)"
+    ACTUAL="$("$NM_TOOL" --defined-only --extern-only "$LIBRARY" | awk '{print $NF}' | sort -u)"
+    ;;
+  # Mach-O: BSD nm, and every C symbol is prefixed with an underscore.
   *) ACTUAL="$(nm -gU "$LIBRARY" | awk '{print $NF}' | sed 's/^_//' | sort -u)" ;;
 esac
 
+# Matched with a here-string, not a pipe: `grep -q` exits at the first hit, and under `pipefail`
+# the `printf` feeding it dies of SIGPIPE once the symbol list outgrows the pipe buffer, so a
+# piped form reports present symbols as missing - nondeterministically, by library size.
 MISSING=""
 while read -r name; do
-  if ! printf '%s\n' "$ACTUAL" | grep -qx "$name"; then
+  if ! grep -qx -- "$name" <<< "$ACTUAL"; then
     MISSING="$MISSING $name"
   fi
 done <<< "$EXPECTED"


### PR DESCRIPTION
Phase 14 bullet: "`mingwX64` export of the runtime's `nuget_*` symbols is verified only by CI's Windows leg, never locally."

The premise was worse than the bullet said: `ci.yml` never called `scripts/verify-runtime-exports.sh` on either leg, and the script hardcoded the macOS dylib path.

- The script auto-selects the linked library by host (macosArm64 dylib, mingwX64 dll, linuxX64 so) and reads PE/ELF exports with the GNU `nm` that Kotlin/Native's own msys2 toolchain ships under `~/.konan/dependencies/`, falling back to `llvm-nm`/`nm` on PATH.
- CI runs the check on both matrix legs right after `packNuget`, so a missing Windows export fails the build instead of surfacing as `EntryPointNotFoundException` in the dotnet tests.
- Pre-existing bug fixed: the per-name `printf | grep -q` under `pipefail` died of SIGPIPE once the symbol list outgrew the pipe buffer and reported present symbols as missing, nondeterministically by library size.

Verified locally on Windows: `OK: all 66 nuget-runtime exports present in test-library/build/bin/mingwX64/releaseShared/test.dll`, IntegrationTests 1720 passed, LeakTests 28 passed.

First of a five-PR Phase 14 stack (this → `nuget_runtime_version` → reverse `NugetError` fold → `launchForCSharp` runtime helper → generator adoption). The C# twin bullet stays open: blocked by its own text on the compiled-assembly packaging decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3bKS5RWqDmkvtFqNzFfYA
